### PR TITLE
Add ZIP support, multi-file upload, and improve OpenRouter OCR handling

### DIFF
--- a/Backend/src/ocrApp/preprocessing.py
+++ b/Backend/src/ocrApp/preprocessing.py
@@ -17,15 +17,21 @@ def convert_file_to_base64_jpg(file) -> str:
     except EOFError:
         pass  # single-frame image
 
-    # Convert to RGB if needed
+    # Convert to RGB 
     if img.mode != "RGB":
         img = img.convert("RGB")
 
-    # Save to BytesIO as JPEG
+    # Resize to reduce payload (VERY IMPORTANT)
+    max_size = (1200, 1200)
+    img.thumbnail(max_size)
+
+    # Save as compressed JPEG
     output = BytesIO()
-    img.save(output, format="JPEG", quality=95)
+    img.save(output, format="JPEG", quality=65, optimize=True)
+
     output.seek(0)
 
-    # Encode as base64 and return as data URL
+    # Encode to base64
     b64 = base64.b64encode(output.read()).decode("utf-8")
-    return f"data:image/jpeg;base64,{b64}"
+
+    return b64

--- a/Backend/src/ocrApp/serializers.py
+++ b/Backend/src/ocrApp/serializers.py
@@ -7,18 +7,29 @@ ALLOWED_IMAGE_TYPES = {
     "image/gif",
 }
 
+ALLOWED_ZIP_TYPES = {
+    "application/zip",
+    "application/x-zip-compressed",
+}
+
 
 def validate_image_file(image_file):
     """
     Validate the uploaded file is an allowed image type.
     Returns an error string if invalid, or None if valid.
     """
-    if image_file.content_type not in ALLOWED_IMAGE_TYPES:
-        return (
-            f"Unsupported file type '{image_file.content_type}'. "
-            f"Allowed types: JPEG, PNG, TIFF, BMP, GIF."
-        )
-    return None
+    content_type = image_file.content_type
+
+    if content_type in ALLOWED_IMAGE_TYPES:
+        return None
+
+    if content_type in ALLOWED_ZIP_TYPES:
+        return None
+
+    return (
+        f"Unsupported file type '{content_type}'. "
+        f"Allowed types: images (JPEG, PNG, TIFF, BMP, GIF) or ZIP files."
+    )
 
 
 def serialize_ocr_result(ocr_image):

--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import mimetypes
+from urllib import response
 import requests
 from django.conf import settings
 from .preprocessing import convert_file_to_base64_jpg
@@ -25,9 +26,14 @@ class GeminiOCRService:
     def __init__(self):
         self.api_key = settings.OPENROUTER_API_KEY
         self.model = settings.OPENROUTER_MODEL
-        self.url = settings.OPENROUTER_BASE_URL
+        self.base_url = settings.OPENROUTER_BASE_URL
+        self.url = f"{self.base_url}/chat/completions"
 
     def recognise(self, file) -> str:
+
+        # Reset file pointer
+        file.seek(0)
+
         # Convert file to JPEG base64 in memory
         image_b64 = convert_file_to_base64_jpg(file)
 
@@ -43,7 +49,7 @@ class GeminiOCRService:
                         {
                             "type": "image_url",
                             "image_url": {
-                                "url": f"data:image/jpeg;base64,{image_b64}"
+                            "url": f"data:image/jpeg;base64,{image_b64}"
                             }
                         }
                     ]
@@ -53,7 +59,6 @@ class GeminiOCRService:
         payload = {
             "model": self.model,
             "messages": messages,
-            "reasoning": {"enabled": False}  # OCR doesn't need reasoning
         }
 
         headers = {
@@ -66,7 +71,10 @@ class GeminiOCRService:
         if response.status_code != 200:
             raise Exception(f"API request failed: {response.text}")
 
-        response_json = response.json()
+        try:
+            response_json = response.json()
+        except ValueError:
+            raise Exception(f"Invalid JSON response: {response.text}")
 
         if "choices" not in response_json:
             raise Exception(f"Invalid API response: {response_json}")

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -1,12 +1,12 @@
-import json
+import zipfile
+import tempfile
+import os
 import logging
-
-from django.http import JsonResponse, Http404
+from django.http import JsonResponse
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 
-from .models import OCRImage
 from .serializers import (
     ALLOWED_IMAGE_TYPES,
     serialize_ocr_result,
@@ -20,18 +20,13 @@ logger = logging.getLogger(__name__)
 
 @method_decorator(csrf_exempt, name="dispatch")
 class ImageUploadAndRecogniseView(View):
-    """
-    POST /api/ocr/upload/
-    Upload a newspaper image and run OCR via Gemini.
-    Returns the recognised text in the response.
-    """
 
     def post(self, request):
+
         # Check if any files are uploaded
         if not request.FILES:
             return JsonResponse({"error": "No files uploaded."}, status=400)
 
-        # Get all files
         files = request.FILES.getlist("images")
 
         if not files:
@@ -42,17 +37,71 @@ class ImageUploadAndRecogniseView(View):
 
         for file in files:
 
-            file.seek(0) 
-            # Validate each file (optional)
-            error = validate_image_file(file)
-            if error:
-                results[file.name] = {"error": error}
-                continue
-
             try:
-                # Run OCR
-                recognised_text = service.recognise(file)
-                results[file.name] = {"text": recognised_text}
+                file.seek(0)
+
+                # =========================
+                # ZIP FILE HANDLING
+                # =========================
+                if file.name.lower().endswith(".zip"):
+
+                    with tempfile.TemporaryDirectory() as temp_dir:
+
+                        zip_path = os.path.join(temp_dir, file.name)
+
+                        # Save zip locally
+                        with open(zip_path, "wb") as f:
+                            for chunk in file.chunks():
+                                f.write(chunk)
+
+                        # Extract ZIP
+                        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                            zip_ref.extractall(temp_dir)
+
+                            for extracted_name in zip_ref.namelist():
+
+                                extracted_path = os.path.join(temp_dir, extracted_name)
+
+                                # skip folders
+                                if not os.path.isfile(extracted_path):
+                                    continue
+
+                                # optional: filter only images
+                                if not extracted_name.lower().endswith(
+                                    (".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp", ".gif")
+                                ):
+                                    continue
+
+                                try:
+                                    with open(extracted_path, "rb") as img_file:
+                                        img_file.seek(0)
+
+                                        recognised_text = service.recognise(img_file)
+
+                                        results[extracted_name] = {
+                                            "text": recognised_text
+                                        }
+
+                                except Exception as e:
+                                    results[extracted_name] = {
+                                        "error": str(e)
+                                    }
+
+                # =========================
+                # NORMAL IMAGE HANDLING
+                # =========================
+                else:
+
+                    error = validate_image_file(file)
+                    if error:
+                        results[file.name] = {"error": error}
+                        continue
+
+                    recognised_text = service.recognise(file)
+
+                    results[file.name] = {
+                        "text": recognised_text
+                    }
 
             except Exception as exc:
                 results[file.name] = {"error": str(exc)}

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -41,6 +41,8 @@ class ImageUploadAndRecogniseView(View):
         results = {}
 
         for file in files:
+
+            file.seek(0) 
             # Validate each file (optional)
             error = validate_image_file(file)
             if error:

--- a/OCR-FRONTEND/src/api.tsx
+++ b/OCR-FRONTEND/src/api.tsx
@@ -16,47 +16,57 @@ export interface TranslateResponse {
  */
 export async function handleTranslate(params: {
   type: 'text' | 'file';
-  data: string | File;
+  data: string | File | File[];
 }): Promise<TranslateResponse> {
   try {
     const { type, data } = params;
 
-    // Determine the file to send
-    let fileToSend: File;
+    const formData = new FormData();
 
+    // TEXT INPUT
     if (type === 'text' && typeof data === 'string') {
-      // Convert text to a File object
-      fileToSend = new File([data], 'text-input.txt', { type: 'text/plain' });
-    } else if (type === 'file' && data instanceof File) {
-      // Validate file type for images and zip files
+      const file = new File([data], 'text-input.txt', { type: 'text/plain' });
+      formData.append('images', file);
+    }
+
+    // FILE INPUT (single OR multiple)
+    else if (type === 'file') {
+
+      const files = (Array.isArray(data) ? data : [data]) as File[];
+
       const allowedTypes = [
         'image/jpeg', 'image/png', 'image/tiff', 'image/bmp', 'image/gif',
         'application/zip', 'application/x-zip-compressed'
       ];
+
       const allowedExtensions = ['.jpg', '.jpeg', '.png', '.tif', '.tiff', '.zip'];
 
-      const fileExtension = data.name.toLowerCase().substring(data.name.lastIndexOf('.'));
-      const isValidType = allowedTypes.includes(data.type) || allowedExtensions.includes(fileExtension);
+      files.forEach((file) => {
+        const fileExtension = file.name.toLowerCase().substring(file.name.lastIndexOf('.'));
 
-      if (!isValidType) {
-        throw new Error(`Unsupported file type. Allowed: JPEG, PNG, TIFF, BMP, GIF, ZIP`);
-      }
+        const isValidType =
+          allowedTypes.includes(file.type) ||
+          allowedExtensions.includes(fileExtension);
 
-      // Use the file directly (could be image or zip)
-      fileToSend = data;
-    } else {
-      throw new Error(`Invalid input: type='${type}' should match data type`);
+        if (!isValidType) {
+          throw new Error(
+            `Unsupported file type (${file.name}). Allowed: JPEG, PNG, TIFF, BMP, GIF, ZIP`
+          );
+        }
+
+        // append each file
+        formData.append('images', file);
+      });
     }
 
-    // Create FormData and append file
-    const formData = new FormData();
-    formData.append('images', fileToSend);
+    else {
+      throw new Error(`Invalid input: type='${type}' does not match data`);
+    }
 
-    // Send POST request to backend
+    // API CALL
     const response = await fetch(`${API_BASE_URL}/upload/`, {
       method: 'POST',
       body: formData,
-      // Don't set Content-Type, let the browser set it with the boundary
     });
 
     if (!response.ok) {
@@ -65,8 +75,10 @@ export async function handleTranslate(params: {
 
     const result: TranslateResponse = await response.json();
     return result;
+
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
     throw new Error(`Failed to translate: ${errorMessage}`);
   }
 }

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -14,19 +14,19 @@ const TABS: { id: Tab; icon: any; label: string }[] = [
 export default function TranslatorPage() {
   const [activeTab, setActiveTab] = useState<Tab>('text');
   const [inputText, setInputText] = useState('');
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [outputText, setOutputText] = useState<string | null>(null);
 
   const handleClear = () => {
     setInputText('');
-    setSelectedFile(null);
+    setSelectedFiles([]);
     setOutputText(null);
     setError(null);
   };
 
-  const hasInput = activeTab === 'text' ? inputText.trim().length > 0 : selectedFile !== null;
+  const hasInput = activeTab === 'text' ? inputText.trim().length > 0 : selectedFiles.length > 0;
 
   return (
     <div className="translator-page">
@@ -80,8 +80,10 @@ export default function TranslatorPage() {
               <div className="file-drop-icon">
                 <FontAwesomeIcon icon={faUpload} />
               </div>
-              {selectedFile ? (
-                <div className="file-drop-title">{selectedFile.name}</div>
+              {selectedFiles.length > 0 ? (
+              <div className="file-drop-title">
+                {selectedFiles.map(f => f.name).join(', ')}
+              </div>
               ) : (
                 <>
                 <div className="file-drop-title">Click to upload or drag and drop</div>
@@ -92,7 +94,8 @@ export default function TranslatorPage() {
               type="file"
               id="file-input"
               style={{ display: 'none' }}
-              onChange={(e) => setSelectedFile(e.target.files?.[0] || null)}
+              multiple
+              onChange={(e) => setSelectedFiles(Array.from(e.target.files || []))}
               accept=".jpg,.jpeg,.png,.tif,.tiff,.zip"
               />
               <label htmlFor="file-input" style={{ display: 'none' }} />
@@ -116,8 +119,10 @@ export default function TranslatorPage() {
                 try {
                   const result = await handleTranslate({
                     type: activeTab,
-                    data: activeTab === 'text' ? inputText : selectedFile!
+                    data: activeTab === 'text' ? inputText : selectedFiles
                   });
+
+                  console.log('Translation API response:', result);
                   
                   // Extract the first result (single file sent)
                   const firstKey = Object.keys(result)[0];


### PR DESCRIPTION
* Added support for multiple file uploads in frontend
* Updated frontend to send multiple images and ZIP files to backend
* Enhanced `views.py` to handle:

  * ZIP file uploads
  * Extraction of images from ZIP archives
  * Processing of multiple images (from both direct upload and ZIP)
* Updated `serializer.py` to accept ZIP file types
* Fixed OpenRouter integration by correcting:

  * Base URL
  * Request payload
* Improved `convert_file_to_base64_jpg` to:

  * Resize images before processing
  * Return clean base64-encoded output
* Ensured backend returns **combined OCR results for all processed files**
