### PR TITLE
Daniel frontend typein api key feature

### DIFF
--- a/Backend/src/OCR_Backend/settings.py
+++ b/Backend/src/OCR_Backend/settings.py
@@ -60,6 +60,19 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
 ]
 
+CORS_ALLOW_HEADERS = [
+    "accept",
+    "accept-encoding",
+    "authorization",
+    "content-type",
+    "dnt",
+    "origin",
+    "user-agent",
+    "x-csrftoken",
+    "x-requested-with",
+    "x-user-api-key",
+]
+
 ROOT_URLCONF = 'OCR_Backend.urls'
 
 TEMPLATES = [

--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -21,10 +21,14 @@ OCR_SYSTEM_PROMPT = (
 class GeminiOCRService:
     """
     Calls the Google Gemini 3.1 Pro model to perform OCR on an uploaded image.
+
+    If api_key is provided it is used only for this request and never stored.
+    Falls back to the server-configured key when no user key is supplied.
     """
 
-    def __init__(self):
-        self.api_key = settings.OPENROUTER_API_KEY
+    def __init__(self, api_key: str | None = None):
+        # Use caller-supplied key if present; never persist it beyond this object's lifetime.
+        self.api_key = api_key if api_key else settings.OPENROUTER_API_KEY
         self.model = settings.OPENROUTER_MODEL
         self.base_url = settings.OPENROUTER_BASE_URL
         self.url = f"{self.base_url}/chat/completions"

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -157,7 +157,12 @@ class CreditsView(View):
     """
 
     def get(self, request):
-        api_key = settings.OPENROUTER_API_KEY
+        raw_key = request.headers.get("X-User-Api-Key") or None
+        user_api_key, key_error = _validate_user_api_key(raw_key)
+        if key_error:
+            return JsonResponse({"error": key_error}, status=400)
+
+        api_key = user_api_key or settings.OPENROUTER_API_KEY
         if not api_key:
             return JsonResponse({"error": "API key not configured."}, status=500)
 

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -1,3 +1,4 @@
+import re
 import zipfile
 import tempfile
 import os
@@ -20,6 +21,28 @@ from .services import GeminiOCRService
 
 logger = logging.getLogger(__name__)
 
+# OpenRouter keys follow the pattern: sk-or-v1-<hex chars>
+# We validate the format so only well-formed keys are forwarded.
+_API_KEY_RE = re.compile(r'^sk-or-v1-[A-Za-z0-9]{1,200}$')
+_API_KEY_MAX_LEN = 220  # hard upper bound to prevent oversized header abuse
+
+
+def _validate_user_api_key(raw: str | None) -> tuple[str | None, str | None]:
+    """
+    Return (key, None) if valid, or (None, error_message) if not.
+    The raw value is never included in the returned error message.
+    """
+    if not raw:
+        return None, None  # no key supplied — fall back to server default
+
+    if len(raw) > _API_KEY_MAX_LEN:
+        return None, "Provided API key exceeds maximum allowed length."
+
+    if not _API_KEY_RE.match(raw):
+        return None, "Provided API key has an invalid format."
+
+    return raw, None
+
 
 @method_decorator(csrf_exempt, name="dispatch")
 class ImageUploadAndRecogniseView(View):
@@ -35,7 +58,20 @@ class ImageUploadAndRecogniseView(View):
         if not files:
             return JsonResponse({"error": "No image files found."}, status=400)
 
-        service = GeminiOCRService()
+        # Read user-supplied API key from header — used only for this request,
+        # never logged or persisted.
+        raw_key = request.headers.get("X-User-Api-Key") or None
+        user_api_key, key_error = _validate_user_api_key(raw_key)
+        if key_error:
+            # Return the error without echoing the raw key value back to the client.
+            return JsonResponse({"error": key_error}, status=400)
+
+        if user_api_key:
+            logger.info("Request is using a user-supplied API key.")
+        else:
+            logger.info("Request is using the server default API key.")
+
+        service = GeminiOCRService(api_key=user_api_key)
         results = {}
 
         for file in files:

--- a/OCR-FRONTEND/src/api.tsx
+++ b/OCR-FRONTEND/src/api.tsx
@@ -10,8 +10,12 @@ export interface CreditsResponse {
 /**
  * Fetch remaining OpenRouter credits from the backend proxy.
  */
-export async function getCredits(): Promise<CreditsResponse> {
-  const response = await fetch(`${API_BASE_URL}/credits/`);
+export async function getCredits(apiKey?: string): Promise<CreditsResponse> {
+  const headers: HeadersInit = {};
+  if (apiKey && apiKey.trim()) {
+    headers['X-User-Api-Key'] = apiKey.trim();
+  }
+  const response = await fetch(`${API_BASE_URL}/credits/`, { headers });
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}: ${response.statusText}`);
   }
@@ -34,9 +38,10 @@ export interface TranslateResponse {
 export async function handleTranslate(params: {
   type: 'text' | 'file';
   data: string | File | File[];
+  apiKey?: string;
 }): Promise<TranslateResponse> {
   try {
-    const { type, data } = params;
+    const { type, data, apiKey } = params;
 
     const formData = new FormData();
 
@@ -81,8 +86,14 @@ export async function handleTranslate(params: {
     }
 
     // API CALL
+    const headers: HeadersInit = {};
+    if (apiKey && apiKey.trim()) {
+      headers['X-User-Api-Key'] = apiKey.trim();
+    }
+
     const response = await fetch(`${API_BASE_URL}/upload/`, {
       method: 'POST',
+      headers,
       body: formData,
     });
 

--- a/OCR-FRONTEND/src/components/Navbar.tsx
+++ b/OCR-FRONTEND/src/components/Navbar.tsx
@@ -6,19 +6,26 @@ import { getCredits } from '../api';
 export default function Navbar() {
   const [remaining, setRemaining] = useState<number | null>(null);
 
-  useEffect(() => {
-    getCredits()
+  const fetchCredits = () => {
+    const key = localStorage.getItem('openrouter_api_key') || undefined;
+    getCredits(key)
       .then((data) => setRemaining(data.remaining))
       .catch(() => setRemaining(null));
+  };
+
+  useEffect(() => {
+    fetchCredits();
 
     // Refresh every 60 seconds
-    const id = setInterval(() => {
-      getCredits()
-        .then((data) => setRemaining(data.remaining))
-        .catch(() => setRemaining(null));
-    }, 60_000);
+    const id = setInterval(fetchCredits, 60_000);
 
-    return () => clearInterval(id);
+    // Re-fetch immediately when user changes their API key
+    window.addEventListener('apikey-changed', fetchCredits);
+
+    return () => {
+      clearInterval(id);
+      window.removeEventListener('apikey-changed', fetchCredits);
+    };
   }, []);
 
   return (

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -47,6 +47,104 @@
   line-height: 1.6;
 }
 
+/* ── API Key Bar ── */
+.api-key-bar {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+}
+
+.api-key-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.api-key-icon {
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.api-key-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.api-key-optional {
+  font-size: 11px;
+  font-weight: 500;
+  color: #9ca3af;
+  background: #f3f4f6;
+  border-radius: 100px;
+  padding: 2px 8px;
+}
+
+.api-key-input-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 200px;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  background: #f9fafb;
+  transition: border-color 0.2s;
+}
+
+.api-key-input-wrapper:focus-within {
+  border-color: #1a1a2e;
+  background: #ffffff;
+}
+
+.api-key-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 9px 12px;
+  font-size: 14px;
+  font-family: 'Courier New', monospace;
+  color: #1a1a2e;
+  outline: none;
+  min-width: 0;
+}
+
+.api-key-input::placeholder {
+  color: #9ca3af;
+  font-family: inherit;
+}
+
+.api-key-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 12px;
+  color: #9ca3af;
+  font-size: 14px;
+  transition: color 0.2s;
+  display: flex;
+  align-items: center;
+}
+
+.api-key-toggle:hover {
+  color: #374151;
+}
+
+.api-key-hint {
+  width: 100%;
+  margin: 0;
+  font-size: 12px;
+  color: #9ca3af;
+  font-weight: 300;
+}
+
 /* ── Side-by-side Panels ── */
 .translator-container {
   max-width: 1200px;

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -22,7 +22,10 @@ import {
   faFileLines,
   faFilePdf,
   faFileWord,
-  faCopy
+  faCopy,
+  faKey,
+  faEye,
+  faEyeSlash
 } from '@fortawesome/free-solid-svg-icons';
 
 type Tab = 'text' | 'file' | 'camera';
@@ -46,6 +49,8 @@ export default function TranslatorPage() {
   const [cameraPreviewUrl, setCameraPreviewUrl] = useState<string | null>(null);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [cameraActive, setCameraActive] = useState(false);
+  const [apiKey, setApiKey] = useState(() => localStorage.getItem('openrouter_api_key') ?? '');
+  const [showApiKey, setShowApiKey] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [outputItems, setOutputItems] = useState<OutputItem[]>([]);
@@ -387,6 +392,45 @@ const exportToDocx = async () => {
           </p>
         </div>
 
+        {/* API Key Input */}
+        <div className="api-key-bar">
+          <div className="api-key-bar-left">
+            <FontAwesomeIcon icon={faKey} className="api-key-icon" />
+            <span className="api-key-label">Your OpenRouter API Key</span>
+            <span className="api-key-optional">optional</span>
+          </div>
+          <div className="api-key-input-wrapper">
+            <input
+              className="api-key-input"
+              type={showApiKey ? 'text' : 'password'}
+              placeholder="sk-or-v1-..."
+              value={apiKey}
+              onChange={(e) => {
+                setApiKey(e.target.value);
+                if (e.target.value.trim()) {
+                  localStorage.setItem('openrouter_api_key', e.target.value);
+                } else {
+                  localStorage.removeItem('openrouter_api_key');
+                }
+                window.dispatchEvent(new Event('apikey-changed'));
+              }}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button
+              className="api-key-toggle"
+              type="button"
+              onClick={() => setShowApiKey((v) => !v)}
+              title={showApiKey ? 'Hide key' : 'Show key'}
+            >
+              <FontAwesomeIcon icon={showApiKey ? faEyeSlash : faEye} />
+            </button>
+          </div>
+          <p className="api-key-hint">
+            Your key is sent directly to the server per request and is never stored.
+          </p>
+        </div>
+
         {/* Side by side panel */}
         <div className="translator-panels">
 
@@ -571,7 +615,8 @@ const exportToDocx = async () => {
                           ? selectedFiles
                           : cameraFile
                             ? [cameraFile]
-                            : []
+                            : [],
+                    apiKey: apiKey.trim() || undefined,
                   });
 
                   console.log('Translation API response:', result);


### PR DESCRIPTION
Title:                                                                                                                                                                 
  feat: add user API key input with localStorage persistence and live credits sync                                                                                       
                  
  Body:                                                                                                                                                                  
   
  ## Summary                                                                                                                                                             
  - Added an API key input box on the Translator page for users to enter their own OpenRouter API key
  - API key is saved to browser localStorage — persists across sessions without being stored on the server                                                               
  - Credits display in Navbar now shows the balance of the user's own key and refreshes immediately when the key changes                                                 
  - Backend updated to accept `X-User-Api-Key` header in both OCR and credits endpoints                                                                                  
  - Added `X-User-Api-Key` to CORS allowed headers so the browser can send it                                                                                            
  ## How it works                                                                                                                                                        
  1. User enters their OpenRouter API key in the input box (`sk-or-v1-...`)                                                                                              
  2. Key is saved to `localStorage` and an `apikey-changed` event is dispatched                                                                                          
  3. Navbar picks up the event and re-fetches credits using the user's key                                                                                               
  4. All subsequent OCR requests use the user's key via request header    
  5. Key is never stored on the server — used per request only                                                                                                           
                                                                                                                                                                         
