### PR TITLE
Daniel backend type in api key feature

### DIFF
--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -21,10 +21,14 @@ OCR_SYSTEM_PROMPT = (
 class GeminiOCRService:
     """
     Calls the Google Gemini 3.1 Pro model to perform OCR on an uploaded image.
+
+    If api_key is provided it is used only for this request and never stored.
+    Falls back to the server-configured key when no user key is supplied.
     """
 
-    def __init__(self):
-        self.api_key = settings.OPENROUTER_API_KEY
+    def __init__(self, api_key: str | None = None):
+        # Use caller-supplied key if present; never persist it beyond this object's lifetime.
+        self.api_key = api_key if api_key else settings.OPENROUTER_API_KEY
         self.model = settings.OPENROUTER_MODEL
         self.base_url = settings.OPENROUTER_BASE_URL
         self.url = f"{self.base_url}/chat/completions"

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -157,7 +157,12 @@ class CreditsView(View):
     """
 
     def get(self, request):
-        api_key = settings.OPENROUTER_API_KEY
+        raw_key = request.headers.get("X-User-Api-Key") or None
+        user_api_key, key_error = _validate_user_api_key(raw_key)
+        if key_error:
+            return JsonResponse({"error": key_error}, status=400)
+
+        api_key = user_api_key or settings.OPENROUTER_API_KEY
         if not api_key:
             return JsonResponse({"error": "API key not configured."}, status=500)
 

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -1,3 +1,4 @@
+import re
 import zipfile
 import tempfile
 import os
@@ -20,6 +21,28 @@ from .services import GeminiOCRService
 
 logger = logging.getLogger(__name__)
 
+# OpenRouter keys follow the pattern: sk-or-v1-<hex chars>
+# We validate the format so only well-formed keys are forwarded.
+_API_KEY_RE = re.compile(r'^sk-or-v1-[A-Za-z0-9]{1,200}$')
+_API_KEY_MAX_LEN = 220  # hard upper bound to prevent oversized header abuse
+
+
+def _validate_user_api_key(raw: str | None) -> tuple[str | None, str | None]:
+    """
+    Return (key, None) if valid, or (None, error_message) if not.
+    The raw value is never included in the returned error message.
+    """
+    if not raw:
+        return None, None  # no key supplied — fall back to server default
+
+    if len(raw) > _API_KEY_MAX_LEN:
+        return None, "Provided API key exceeds maximum allowed length."
+
+    if not _API_KEY_RE.match(raw):
+        return None, "Provided API key has an invalid format."
+
+    return raw, None
+
 
 @method_decorator(csrf_exempt, name="dispatch")
 class ImageUploadAndRecogniseView(View):
@@ -35,7 +58,20 @@ class ImageUploadAndRecogniseView(View):
         if not files:
             return JsonResponse({"error": "No image files found."}, status=400)
 
-        service = GeminiOCRService()
+        # Read user-supplied API key from header — used only for this request,
+        # never logged or persisted.
+        raw_key = request.headers.get("X-User-Api-Key") or None
+        user_api_key, key_error = _validate_user_api_key(raw_key)
+        if key_error:
+            # Return the error without echoing the raw key value back to the client.
+            return JsonResponse({"error": key_error}, status=400)
+
+        if user_api_key:
+            logger.info("Request is using a user-supplied API key.")
+        else:
+            logger.info("Request is using the server default API key.")
+
+        service = GeminiOCRService(api_key=user_api_key)
         results = {}
 
         for file in files:


### PR DESCRIPTION
## Summary                                                                                                                                                             
  - Backend now accepts user-supplied OpenRouter API key via `X-User-Api-Key` request header
  - Both OCR upload and credits endpoints support user key, falling back to server default if not provided                                                               
  - Added key format validation (sk-or-v1-*) and length limit to prevent malformed input                                                                                 
  - Added `X-User-Api-Key` to CORS allowed headers                                                                                                                       
                                                                                                                                                                         
  ## How it works                                                                                                                                                        
  1. Client sends API key in `X-User-Api-Key` header                                                                                                                     
  2. Backend validates format and length — rejects invalid keys with 400 error
  3. Valid key is used for this request only, never logged or stored 