### PR TITLE
perf(backend): parallel OCR processing to reduce multi-file wait time

### DIFF
--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -70,7 +70,7 @@ class GeminiOCRService:
             "Content-Type": "application/json"
         }
 
-        response = requests.post(self.url, headers=headers, json=payload)
+        response = requests.post(self.url, headers=headers, json=payload, timeout=300)
 
         if response.status_code != 200:
             raise Exception(f"API request failed: {response.text}")

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -3,6 +3,8 @@ import zipfile
 import tempfile
 import os
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from io import BytesIO
 
 import requests
 from django.conf import settings
@@ -72,10 +74,14 @@ class ImageUploadAndRecogniseView(View):
             logger.info("Request is using the server default API key.")
 
         service = GeminiOCRService(api_key=user_api_key)
+
+        # Collect all (name, file_bytes) tasks to process in parallel.
+        # Files are read into memory in the main thread before handing off,
+        # as Django's UploadedFile objects are not thread-safe.
+        tasks: list[tuple[str, bytes]] = []
         results = {}
 
         for file in files:
-
             try:
                 file.seek(0)
 
@@ -88,12 +94,10 @@ class ImageUploadAndRecogniseView(View):
 
                         zip_path = os.path.join(temp_dir, file.name)
 
-                        # Save zip locally
                         with open(zip_path, "wb") as f:
                             for chunk in file.chunks():
                                 f.write(chunk)
 
-                        # Extract ZIP
                         with zipfile.ZipFile(zip_path, 'r') as zip_ref:
                             for extracted_name in zip_ref.namelist():
 
@@ -105,49 +109,44 @@ class ImageUploadAndRecogniseView(View):
 
                                 zip_ref.extract(extracted_name, temp_dir)
 
-                                # skip folders
                                 if not os.path.isfile(extracted_path):
                                     continue
 
-                                # filter only images
                                 if not extracted_name.lower().endswith(
                                     (".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp", ".gif")
                                 ):
                                     continue
 
-                                try:
-                                    with open(extracted_path, "rb") as img_file:
-                                        img_file.seek(0)
-
-                                        recognised_text = service.recognise(img_file)
-
-                                        results[extracted_name] = {
-                                            "text": recognised_text
-                                        }
-
-                                except Exception as e:
-                                    results[extracted_name] = {
-                                        "error": str(e)
-                                    }
+                                with open(extracted_path, "rb") as img_file:
+                                    tasks.append((extracted_name, img_file.read()))
 
                 # =========================
                 # NORMAL IMAGE HANDLING
                 # =========================
                 else:
-
                     error = validate_image_file(file)
                     if error:
                         results[file.name] = {"error": error}
                         continue
 
-                    recognised_text = service.recognise(file)
-
-                    results[file.name] = {
-                        "text": recognised_text
-                    }
+                    tasks.append((file.name, file.read()))
 
             except Exception as exc:
                 results[file.name] = {"error": str(exc)}
+
+        # Process all collected images in parallel
+        def recognise_task(name: str, file_bytes: bytes) -> tuple[str, dict]:
+            try:
+                recognised_text = service.recognise(BytesIO(file_bytes))
+                return name, {"text": recognised_text}
+            except Exception as e:
+                return name, {"error": str(e)}
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(recognise_task, name, data): name for name, data in tasks}
+            for future in as_completed(futures):
+                name, result = future.result()
+                results[name] = result
 
         return JsonResponse(results, status=200)
 


### PR DESCRIPTION
 ## Summary      
  - OCR processing for multiple files is now parallel instead of sequential                                                                                              
  - Added request timeout to prevent infinite waiting on slow API responses
                                                                                                                                                                         
  ## Problem
  Previously files were processed one by one — 5 files at 3 min each = 15 min total wait time.                                                                           
                                                                                                                                                                         
  ## Solution
  - Used `ThreadPoolExecutor(max_workers=5)` to process up to 5 files simultaneously                                                                                     
  - Files are pre-read into memory in the main thread before being handed to workers (thread safety)                                                                     
  - ZIP file contents are also included in parallel processing                                                                                                           
  - Added `timeout=300` to OpenRouter API calls to prevent infinite hanging                                                                                              
                                                                                                                                                                         
  - 5 files: ~15 min → ~3-4 min                                                                                                                                          
  - Single file: unchanged (~3 min, limited by model speed)                                                                                                              
                                                           
  ## Files changed                                                                                                                                                       
  - `Backend/src/ocrApp/services.py` — added timeout=300 to API request
  - `Backend/src/ocrApp/views.py` — refactored to use ThreadPoolExecutor 