### PR TITLE
Add camera source selector for desktop capture

### DIFF
--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -364,6 +364,36 @@
   gap: 10px;
 }
 
+.camera-device-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.camera-device-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #374151;
+}
+
+.camera-device-select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1.5px solid #d1d5db;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1a1a2e;
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.camera-device-select:focus {
+  border-color: #1a1a2e;
+  box-shadow: 0 0 0 2px rgba(26, 26, 46, 0.08);
+}
+
 .camera-action-btn {
   display: inline-flex;
   align-items: center;

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -34,6 +34,10 @@ type OutputItem = {
   text?: string;
   error?: string;
 };
+type CameraOption = {
+  deviceId: string;
+  label: string;
+};
 
 const TABS: { id: Tab; icon: any; label: string }[] = [
   { id: 'text', icon: faPenToSquare, label: 'Text' },
@@ -49,6 +53,8 @@ export default function TranslatorPage() {
   const [cameraPreviewUrl, setCameraPreviewUrl] = useState<string | null>(null);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [cameraActive, setCameraActive] = useState(false);
+  const [cameraDevices, setCameraDevices] = useState<CameraOption[]>([]);
+  const [selectedCameraId, setSelectedCameraId] = useState('');
   const [apiKey, setApiKey] = useState(() => localStorage.getItem('openrouter_api_key') ?? '');
   const [showApiKey, setShowApiKey] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -67,6 +73,9 @@ export default function TranslatorPage() {
     typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(pointer: coarse)').matches;
+  const supportsDeviceEnumeration =
+    typeof navigator !== 'undefined' &&
+    Boolean(navigator.mediaDevices?.enumerateDevices);
 
   useEffect(() => {
     if (!cameraFile) {
@@ -130,6 +139,74 @@ export default function TranslatorPage() {
     void playPreview();
   }, [cameraActive]);
 
+  useEffect(() => {
+    if (!supportsDeviceEnumeration || prefersNativeCameraCapture) {
+      return;
+    }
+
+    const syncDevices = async () => {
+      try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const videoInputs = devices
+          .filter((device) => device.kind === 'videoinput')
+          .map((device, index) => ({
+            deviceId: device.deviceId,
+            label: device.label || `Camera ${index + 1}`,
+          }));
+
+        setCameraDevices(videoInputs);
+
+        if (!selectedCameraId && videoInputs.length > 0) {
+          setSelectedCameraId(videoInputs[0].deviceId);
+        }
+      } catch {
+        // Ignore enumeration failures and continue with facingMode fallback.
+      }
+    };
+
+    void syncDevices();
+
+    const handleDeviceChange = () => {
+      void syncDevices();
+    };
+
+    navigator.mediaDevices.addEventListener?.('devicechange', handleDeviceChange);
+
+    return () => {
+      navigator.mediaDevices.removeEventListener?.('devicechange', handleDeviceChange);
+    };
+  }, [prefersNativeCameraCapture, selectedCameraId, supportsDeviceEnumeration]);
+
+  const refreshCameraDevices = async (activeStream?: MediaStream) => {
+    if (!supportsDeviceEnumeration || prefersNativeCameraCapture) {
+      return;
+    }
+
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const videoInputs = devices
+        .filter((device) => device.kind === 'videoinput')
+        .map((device, index) => ({
+          deviceId: device.deviceId,
+          label: device.label || `Camera ${index + 1}`,
+        }));
+
+      setCameraDevices(videoInputs);
+
+      const activeDeviceId = activeStream?.getVideoTracks?.()[0]?.getSettings?.().deviceId;
+      if (activeDeviceId) {
+        setSelectedCameraId(activeDeviceId);
+        return;
+      }
+
+      if (!selectedCameraId && videoInputs.length > 0) {
+        setSelectedCameraId(videoInputs[0].deviceId);
+      }
+    } catch {
+      // Ignore enumeration failures and continue with the active stream.
+    }
+  };
+
   const stopCamera = () => {
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((track) => track.stop());
@@ -183,7 +260,7 @@ export default function TranslatorPage() {
     }
   };
 
-  const startCamera = async () => {
+  const startCamera = async (deviceIdOverride?: string) => {
     if (!supportsLiveCamera) {
       setCameraError('Live camera preview is not supported in this browser.');
       return;
@@ -196,10 +273,13 @@ export default function TranslatorPage() {
       let stream: MediaStream;
 
       try {
+        const preferredDeviceId = deviceIdOverride || selectedCameraId;
+        const videoConstraints = preferredDeviceId
+          ? { deviceId: { exact: preferredDeviceId } }
+          : { facingMode: { ideal: preferredFacingMode } };
+
         stream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            facingMode: { ideal: preferredFacingMode },
-          },
+          video: videoConstraints,
           audio: false,
         });
       } catch {
@@ -213,6 +293,7 @@ export default function TranslatorPage() {
       streamRef.current = stream;
       setCameraActive(true);
       setCameraError(null);
+      await refreshCameraDevices(stream);
     } catch (cameraAccessError) {
       const message =
         cameraAccessError instanceof Error
@@ -289,6 +370,21 @@ export default function TranslatorPage() {
   const retakePhoto = () => {
     setCameraFile(null);
     setCameraError(null);
+  };
+
+  const handleCameraSelectionChange = async (deviceId: string) => {
+    setSelectedCameraId(deviceId);
+    setCameraError(null);
+
+    if (!cameraActive) {
+      return;
+    }
+
+    try {
+      await startCamera(deviceId);
+    } catch {
+      // startCamera already reports a user-facing error.
+    }
   };
 
 const copyOutputToClipboard = async () => {
@@ -566,6 +662,28 @@ const exportToDocx = async () => {
                     </button>
                   )}
                 </div>
+
+                {!prefersNativeCameraCapture && cameraDevices.length > 1 && (
+                  <div className="camera-device-row">
+                    <label className="camera-device-label" htmlFor="camera-device-select">
+                      Camera source
+                    </label>
+                    <select
+                      id="camera-device-select"
+                      className="camera-device-select"
+                      value={selectedCameraId}
+                      onChange={(e) => {
+                        void handleCameraSelectionChange(e.target.value);
+                      }}
+                    >
+                      {cameraDevices.map((device) => (
+                        <option key={device.deviceId} value={device.deviceId}>
+                          {device.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
 
                 <input
                   ref={cameraInputRef}

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -106,6 +106,30 @@ export default function TranslatorPage() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!cameraActive || !videoRef.current || !streamRef.current) {
+      return;
+    }
+
+    const videoElement = videoRef.current;
+    videoElement.srcObject = streamRef.current;
+
+    const playPreview = async () => {
+      try {
+        await videoElement.play();
+      } catch (playbackError) {
+        const message =
+          playbackError instanceof Error
+            ? playbackError.message
+            : 'Unable to start the camera preview.';
+
+        setCameraError(`Camera preview failed: ${message}`);
+      }
+    };
+
+    void playPreview();
+  }, [cameraActive]);
+
   const stopCamera = () => {
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((track) => track.stop());
@@ -167,21 +191,26 @@ export default function TranslatorPage() {
 
     try {
       stopCamera();
+      const preferredFacingMode = prefersNativeCameraCapture ? 'environment' : 'user';
 
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: {
-          facingMode: { ideal: 'environment' },
-        },
-        audio: false,
-      });
+      let stream: MediaStream;
 
-      streamRef.current = stream;
-
-      if (videoRef.current) {
-        videoRef.current.srcObject = stream;
-        await videoRef.current.play();
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            facingMode: { ideal: preferredFacingMode },
+          },
+          audio: false,
+        });
+      } catch {
+        // Fall back to the default camera if the preferred facing mode is unavailable.
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+          audio: false,
+        });
       }
 
+      streamRef.current = stream;
       setCameraActive(true);
       setCameraError(null);
     } catch (cameraAccessError) {


### PR DESCRIPTION
## Summary
- keep desktop capture defaulting to the front-facing camera when available
- add a camera source selector when multiple desktop cameras are detected
- switch the live preview immediately when a different camera is selected
- keep the existing mobile native capture flow unchanged

## Testing
- verified frontend build succeeds with `npm run build`
- tested camera capture flow and desktop preview logic locally
