### PR TITLE
Add translator processing progress UI

### DIFF
--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -207,6 +207,62 @@
   font-weight: 300;
 }
 
+.progress-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 16px;
+  padding: 28px 8px;
+}
+
+.progress-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.progress-card-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.progress-card-percent {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+.progress-track {
+  position: relative;
+  width: 100%;
+  height: 12px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #1a1a2e 0%, #3f3c68 100%);
+  transition: width 0.18s ease-out;
+}
+
+.progress-card-meta {
+  font-size: 14px;
+  font-weight: 500;
+  color: #4b5563;
+}
+
+.progress-card-hint {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #6b7280;
+}
+
 
 .input-card {
   background: #ffffff;

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -58,6 +58,8 @@ export default function TranslatorPage() {
   const [apiKey, setApiKey] = useState(() => localStorage.getItem('openrouter_api_key') ?? '');
   const [showApiKey, setShowApiKey] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [progressValue, setProgressValue] = useState(0);
+  const [elapsedMs, setElapsedMs] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [outputItems, setOutputItems] = useState<OutputItem[]>([]);
   const [copied, setCopied] = useState(false);
@@ -66,6 +68,10 @@ export default function TranslatorPage() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const progressIntervalRef = useRef<number | null>(null);
+  const requestStartedAtRef = useRef<number | null>(null);
+  const progressValueRef = useRef(0);
+  const elapsedMsRef = useRef(0);
   const supportsLiveCamera =
     typeof navigator !== 'undefined' &&
     Boolean(navigator.mediaDevices?.getUserMedia);
@@ -92,6 +98,14 @@ export default function TranslatorPage() {
   }, [cameraFile]);
 
   useEffect(() => {
+    progressValueRef.current = progressValue;
+  }, [progressValue]);
+
+  useEffect(() => {
+    elapsedMsRef.current = elapsedMs;
+  }, [elapsedMs]);
+
+  useEffect(() => {
     if (activeTab === 'camera' || !streamRef.current) {
       return;
     }
@@ -108,12 +122,88 @@ export default function TranslatorPage() {
 
   useEffect(() => {
     return () => {
+      if (progressIntervalRef.current) {
+        window.clearInterval(progressIntervalRef.current);
+        progressIntervalRef.current = null;
+      }
+
       if (streamRef.current) {
         streamRef.current.getTracks().forEach((track) => track.stop());
         streamRef.current = null;
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (!loading) {
+      if (progressIntervalRef.current) {
+        window.clearInterval(progressIntervalRef.current);
+        progressIntervalRef.current = null;
+      }
+      return;
+    }
+
+    requestStartedAtRef.current = performance.now();
+
+    const tickProgress = () => {
+      if (requestStartedAtRef.current === null) {
+        return;
+      }
+
+      const nextElapsedMs = performance.now() - requestStartedAtRef.current;
+      let nextProgress = 12;
+
+      if (nextElapsedMs < 800) {
+        nextProgress = 12 + (nextElapsedMs / 800) * 24;
+      } else if (nextElapsedMs < 2500) {
+        nextProgress = 36 + ((nextElapsedMs - 800) / 1700) * 28;
+      } else if (nextElapsedMs < 6000) {
+        nextProgress = 64 + ((nextElapsedMs - 2500) / 3500) * 18;
+      } else {
+        nextProgress = 82 + Math.min(((nextElapsedMs - 6000) / 12000) * 10, 10);
+      }
+
+      setElapsedMs(nextElapsedMs);
+      setProgressValue((current) => Math.max(current, Math.min(nextProgress, 92)));
+    };
+
+    tickProgress();
+    progressIntervalRef.current = window.setInterval(tickProgress, 120);
+
+    return () => {
+      if (progressIntervalRef.current) {
+        window.clearInterval(progressIntervalRef.current);
+        progressIntervalRef.current = null;
+      }
+    };
+  }, [loading]);
+
+  const finishProgressAnimation = async () => {
+    if (progressIntervalRef.current) {
+      window.clearInterval(progressIntervalRef.current);
+      progressIntervalRef.current = null;
+    }
+
+    setProgressValue(100);
+
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 280);
+    });
+  };
+
+  const formatElapsedTime = (valueMs: number) => {
+    if (valueMs < 1000) {
+      return `${Math.max(0.1, valueMs / 1000).toFixed(1)} s`;
+    }
+
+    if (valueMs < 60000) {
+      return `${(valueMs / 1000).toFixed(1)} s`;
+    }
+
+    const minutes = Math.floor(valueMs / 60000);
+    const seconds = ((valueMs % 60000) / 1000).toFixed(1);
+    return `${minutes}m ${seconds}s`;
+  };
 
   useEffect(() => {
     if (!cameraActive || !videoRef.current || !streamRef.current) {
@@ -230,6 +320,9 @@ export default function TranslatorPage() {
     setOutputItems([]);
     setCopied(false);
     setError(null);
+    setProgressValue(0);
+    setElapsedMs(0);
+    requestStartedAtRef.current = null;
 
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
@@ -752,6 +845,8 @@ const exportToDocx = async () => {
                 setLoading(true);
                 setError(null);
                 setOutputItems([]);
+                setProgressValue(0);
+                setElapsedMs(0);
 
                 try {
                   const result = await handleTranslate({
@@ -775,15 +870,19 @@ const exportToDocx = async () => {
                     })
                   );
 
+                  await finishProgressAnimation();
+
                   if (formattedResults.length === 0) {
                     setError('No output received from server.');
                   } else {
                     setOutputItems(formattedResults);
                   }
                 } catch (err) {
+                  await finishProgressAnimation();
                   setError(err instanceof Error ? err.message : 'Unknown error occurred');
                 } finally {
-                setLoading(false);
+                  requestStartedAtRef.current = null;
+                  setLoading(false);
                 }
               }}
               >
@@ -821,11 +920,23 @@ const exportToDocx = async () => {
               </div>
             )}
             {loading ? (
-              <div className="output-empty">
-                <div className="output-empty-icon">
-                  <FontAwesomeIcon icon={faFileLines} />
+              <div className="progress-card">
+                <div className="progress-card-header">
+                  <div className="progress-card-title">Processing your document...</div>
+                  <div className="progress-card-percent">{Math.round(progressValue)}%</div>
                 </div>
-                <div className="output-empty-text">Processing...</div>
+                <div className="progress-track">
+                  <div
+                    className="progress-fill"
+                    style={{ width: `${progressValue}%` }}
+                  />
+                </div>
+                <div className="progress-card-meta">
+                  Elapsed time: {formatElapsedTime(elapsedMs)}
+                </div>
+                <div className="progress-card-hint">
+                  OCR is running. Translation output will appear automatically when processing completes.
+                </div>
               </div>
             ) : error ? (
               <div className="output-error">


### PR DESCRIPTION
## Summary
- add a progress card to the translator output panel while OCR is running
- show a smooth front-end progress bar instead of a static loading message
- display real elapsed time during processing
- complete the progress bar to 100% before showing the final translation output

## Scope
- frontend only
- no backend API changes

## Files changed
- OCR-FRONTEND/src/pages/TranslatorPage.tsx
- OCR-FRONTEND/src/css/TranslatorPage.css

## Testing
- verified the progress UI appears after clicking Process & Translate
- verified the translation result replaces the progress card after the request completes
- verified frontend production build succeeds with `npm run build`
