### PR TITLE
Improve Translator page API key UX with floating popover and saved-status feedback

### DIFF
--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -781,3 +781,17 @@
     width: 100%;
   }
 }
+
+.api-key-status {
+  font-size: 12px;
+  margin-top: 8px;
+  font-weight: 500;
+}
+
+.api-key-status.saved {
+  color: #16a34a; /* green */
+}
+
+.api-key-status.empty {
+  color: #9ca3af; /* grey */
+}

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -47,102 +47,87 @@
   line-height: 1.6;
 }
 
-/* ── API Key Bar ── */
-.api-key-bar {
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 16px 20px;
-  margin-bottom: 20px;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+.translator-header {
+  position: relative;
 }
 
-.api-key-bar-left {
-  display: flex;
+.translator-api-floating {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.translator-api-trigger {
+  display: inline-flex;
   align-items: center;
   gap: 8px;
-  white-space: nowrap;
-}
-
-.api-key-icon {
-  color: #6b7280;
-  font-size: 13px;
-}
-
-.api-key-label {
+  padding: 10px 14px;
+  background: #ffffff;
+  color: #374151;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
   font-size: 13px;
   font-weight: 600;
-  color: #374151;
-}
-
-.api-key-optional {
-  font-size: 11px;
-  font-weight: 500;
-  color: #9ca3af;
-  background: #f3f4f6;
-  border-radius: 100px;
-  padding: 2px 8px;
-}
-
-.api-key-input-wrapper {
-  display: flex;
-  align-items: center;
-  flex: 1;
-  min-width: 200px;
-  border: 1.5px solid #e5e7eb;
-  border-radius: 8px;
-  background: #f9fafb;
-  transition: border-color 0.2s;
-}
-
-.api-key-input-wrapper:focus-within {
-  border-color: #1a1a2e;
-  background: #ffffff;
-}
-
-.api-key-input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  padding: 9px 12px;
-  font-size: 14px;
-  font-family: 'Courier New', monospace;
-  color: #1a1a2e;
-  outline: none;
-  min-width: 0;
-}
-
-.api-key-input::placeholder {
-  color: #9ca3af;
   font-family: inherit;
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
 }
 
-.api-key-toggle {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0 12px;
-  color: #9ca3af;
-  font-size: 14px;
-  transition: color 0.2s;
+.translator-api-trigger:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+  transform: translateY(-1px);
+}
+
+.translator-api-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 320px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 16px;
+  text-align: left;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.12);
+  z-index: 20;
+}
+
+.translator-api-popover-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
-.api-key-toggle:hover {
-  color: #374151;
+.translator-api-popover-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1a1a2e;
 }
 
-.api-key-hint {
-  width: 100%;
-  margin: 0;
+.translator-api-popover-hint {
+  margin-top: 10px;
   font-size: 12px;
-  color: #9ca3af;
-  font-weight: 300;
+  line-height: 1.5;
+  color: #6b7280;
+}
+
+@media (max-width: 700px) {
+  .translator-api-floating {
+    position: static;
+    margin-top: 16px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .translator-api-popover {
+    right: 50%;
+    transform: translateX(50%);
+    width: min(320px, calc(100vw - 40px));
+  }
 }
 
 /* ── Side-by-side Panels ── */

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -648,6 +648,13 @@ const exportToDocx = async () => {
                 </div>
 
                 <div className="api-key-input-wrapper">
+                  <div
+                    className={`api-key-status ${
+                      apiKey.trim() ? 'saved' : 'empty'
+                    }`}
+                  >
+                    {apiKey.trim() ? 'Key saved in this browser' : 'No key saved'}
+                  </div>
                   <input
                     className="api-key-input"
                     type={showApiKey ? 'text' : 'password'}

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -82,6 +82,7 @@ export default function TranslatorPage() {
   const supportsDeviceEnumeration =
     typeof navigator !== 'undefined' &&
     Boolean(navigator.mediaDevices?.enumerateDevices);
+  const [showApiPanel, setShowApiPanel] = useState(false);
 
   useEffect(() => {
     if (!cameraFile) {
@@ -608,46 +609,58 @@ const exportToDocx = async () => {
           <p className="translator-subtitle">
             Convert historical Fraktur font documents into readable modern German text
           </p>
-        </div>
-
-        {/* API Key Input */}
-        <div className="api-key-bar">
-          <div className="api-key-bar-left">
-            <FontAwesomeIcon icon={faKey} className="api-key-icon" />
-            <span className="api-key-label">Your OpenRouter API Key</span>
-            <span className="api-key-optional">optional</span>
-          </div>
-          <div className="api-key-input-wrapper">
-            <input
-              className="api-key-input"
-              type={showApiKey ? 'text' : 'password'}
-              placeholder="sk-or-v1-..."
-              value={apiKey}
-              onChange={(e) => {
-                setApiKey(e.target.value);
-                if (e.target.value.trim()) {
-                  localStorage.setItem('openrouter_api_key', e.target.value);
-                } else {
-                  localStorage.removeItem('openrouter_api_key');
-                }
-                window.dispatchEvent(new Event('apikey-changed'));
-              }}
-              autoComplete="off"
-              spellCheck={false}
-            />
+          <div className="translator-api-floating">
             <button
-              className="api-key-toggle"
               type="button"
-              onClick={() => setShowApiKey((v) => !v)}
-              title={showApiKey ? 'Hide key' : 'Show key'}
+              className="translator-api-trigger"
+              onClick={() => setShowApiPanel((v) => !v)}
+              title="API key settings"
             >
-              <FontAwesomeIcon icon={showApiKey ? faEyeSlash : faEye} />
+              <FontAwesomeIcon icon={faKey} />
+              <span>API Key</span>
             </button>
+
+            {showApiPanel && (
+              <div className="translator-api-popover">
+                <div className="translator-api-popover-header">
+                  <div className="translator-api-popover-title">OpenRouter API Key</div>
+                  <span className="api-key-optional">optional</span>
+                </div>
+
+                <div className="api-key-input-wrapper">
+                  <input
+                    className="api-key-input"
+                    type={showApiKey ? 'text' : 'password'}
+                    placeholder="sk-or-v1-..."
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      if (e.target.value.trim()) {
+                        localStorage.setItem('openrouter_api_key', e.target.value);
+                      } else {
+                        localStorage.removeItem('openrouter_api_key');
+                      }
+                      window.dispatchEvent(new Event('apikey-changed'));
+                    }}
+                    autoComplete="off"
+                    spellCheck={false}
+                  />
+                  <button
+                    className="api-key-toggle"
+                    type="button"
+                    onClick={() => setShowApiKey((v) => !v)}
+                    title={showApiKey ? 'Hide key' : 'Show key'}
+                  >
+                    <FontAwesomeIcon icon={showApiKey ? faEyeSlash : faEye} />
+                  </button>
+                </div>
+
+                <p className="translator-api-popover-hint">
+                  Your key is sent per request and stored only in your browser. Clear it when using a shared computer.
+                </p>
+              </div>
+            )}
           </div>
-          <p className="api-key-hint">
-            Your key is sent per request and never stored on the server. It is saved in your browser only.
-            If you are on a shared or public computer, clear the key when done.
-          </p>
         </div>
 
         {/* Side by side panel */}

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -72,6 +72,7 @@ export default function TranslatorPage() {
   const requestStartedAtRef = useRef<number | null>(null);
   const progressValueRef = useRef(0);
   const elapsedMsRef = useRef(0);
+  const apiPanelRef = useRef<HTMLDivElement | null>(null);
   const supportsLiveCamera =
     typeof navigator !== 'undefined' &&
     Boolean(navigator.mediaDevices?.getUserMedia);
@@ -178,6 +179,25 @@ export default function TranslatorPage() {
       }
     };
   }, [loading]);
+
+  useEffect(() => {
+    if (!showApiPanel) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        apiPanelRef.current &&
+        !apiPanelRef.current.contains(event.target as Node)
+      ) {
+        setShowApiPanel(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showApiPanel]);
 
   const finishProgressAnimation = async () => {
     if (progressIntervalRef.current) {
@@ -609,7 +629,7 @@ const exportToDocx = async () => {
           <p className="translator-subtitle">
             Convert historical Fraktur font documents into readable modern German text
           </p>
-          <div className="translator-api-floating">
+          <div className="translator-api-floating" ref={apiPanelRef}>
             <button
               type="button"
               className="translator-api-trigger"


### PR DESCRIPTION
This PR improves the API key experience on the Translator page by making it less intrusive and easier to use.

Key updates:
- Repositioned the API key input into a dashboard-style floating popover
- Added show/hide support for the API key value
- Added outside-click behavior to close the popover
- Added a saved-status indicator to show whether a key is stored in the browser
- Kept the API key workflow accessible without affecting the main translator layout

These changes improve usability and reduce visual clutter on the page.

Closes #47