### PR TITLE
fix: improve UX and error handling for file upload and OCR processing

### DIFF
--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -83,4 +83,10 @@ class GeminiOCRService:
         if "choices" not in response_json:
             raise Exception(f"Invalid API response: {response_json}")
 
-        return response_json['choices'][0]['message']['content'].strip()
+        choice = response_json['choices'][0]
+        content = choice['message']['content']
+        if content is None:
+            finish_reason = choice.get('finish_reason', 'unknown')
+            raise Exception(f"Model returned empty content (finish_reason: {finish_reason}).")
+
+        return content.strip()

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -101,6 +101,11 @@ class ImageUploadAndRecogniseView(View):
                         with zipfile.ZipFile(zip_path, 'r') as zip_ref:
                             for extracted_name in zip_ref.namelist():
 
+                                # Skip macOS metadata files (__MACOSX/ dir and ._* resource forks)
+                                base_filename = os.path.basename(extracted_name)
+                                if extracted_name.startswith("__MACOSX/") or base_filename.startswith("._"):
+                                    continue
+
                                 # Security: prevent path traversal attacks
                                 extracted_path = os.path.realpath(os.path.join(temp_dir, extracted_name))
                                 if not extracted_path.startswith(os.path.realpath(temp_dir)):

--- a/OCR-FRONTEND/src/api.tsx
+++ b/OCR-FRONTEND/src/api.tsx
@@ -35,78 +35,77 @@ export interface TranslateResponse {
  * @param params - Object containing type ('text' or 'file') and data (string, image file, or zip file)
  * @returns Promise with recognized text results
  */
-export async function handleTranslate(params: {
+export function handleTranslate(params: {
   type: 'text' | 'file';
   data: string | File | File[];
   apiKey?: string;
+  onUploadDone?: () => void;
 }): Promise<TranslateResponse> {
-  try {
-    const { type, data, apiKey } = params;
+  const { type, data, apiKey, onUploadDone } = params;
 
-    const formData = new FormData();
+  const formData = new FormData();
 
-    // TEXT INPUT
-    if (type === 'text' && typeof data === 'string') {
-      const file = new File([data], 'text-input.txt', { type: 'text/plain' });
+  // TEXT INPUT
+  if (type === 'text' && typeof data === 'string') {
+    const file = new File([data], 'text-input.txt', { type: 'text/plain' });
+    formData.append('images', file);
+  }
+
+  // FILE INPUT (single OR multiple)
+  else if (type === 'file') {
+    const files = (Array.isArray(data) ? data : [data]) as File[];
+
+    const allowedTypes = [
+      'image/jpeg', 'image/png', 'image/tiff', 'image/bmp', 'image/gif',
+      'application/zip', 'application/x-zip-compressed'
+    ];
+    const allowedExtensions = ['.jpg', '.jpeg', '.png', '.tif', '.tiff', '.zip'];
+
+    files.forEach((file) => {
+      const fileExtension = file.name.toLowerCase().substring(file.name.lastIndexOf('.'));
+      const isValidType =
+        allowedTypes.includes(file.type) || allowedExtensions.includes(fileExtension);
+
+      if (!isValidType) {
+        throw new Error(
+          `Unsupported file type (${file.name}). Allowed: JPEG, PNG, TIFF, BMP, GIF, ZIP`
+        );
+      }
       formData.append('images', file);
-    }
+    });
+  }
 
-    // FILE INPUT (single OR multiple)
-    else if (type === 'file') {
+  else {
+    return Promise.reject(new Error(`Invalid input: type='${type}' does not match data`));
+  }
 
-      const files = (Array.isArray(data) ? data : [data]) as File[];
+  // Use XHR so we can detect the moment upload finishes (before server processes)
+  return new Promise<TranslateResponse>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
 
-      const allowedTypes = [
-        'image/jpeg', 'image/png', 'image/tiff', 'image/bmp', 'image/gif',
-        'application/zip', 'application/x-zip-compressed'
-      ];
-
-      const allowedExtensions = ['.jpg', '.jpeg', '.png', '.tif', '.tiff', '.zip'];
-
-      files.forEach((file) => {
-        const fileExtension = file.name.toLowerCase().substring(file.name.lastIndexOf('.'));
-
-        const isValidType =
-          allowedTypes.includes(file.type) ||
-          allowedExtensions.includes(fileExtension);
-
-        if (!isValidType) {
-          throw new Error(
-            `Unsupported file type (${file.name}). Allowed: JPEG, PNG, TIFF, BMP, GIF, ZIP`
-          );
-        }
-
-        // append each file
-        formData.append('images', file);
-      });
-    }
-
-    else {
-      throw new Error(`Invalid input: type='${type}' does not match data`);
-    }
-
-    // API CALL
-    const headers: HeadersInit = {};
-    if (apiKey && apiKey.trim()) {
-      headers['X-User-Api-Key'] = apiKey.trim();
-    }
-
-    const response = await fetch(`${API_BASE_URL}/upload/`, {
-      method: 'POST',
-      headers,
-      body: formData,
+    xhr.upload.addEventListener('load', () => {
+      onUploadDone?.();
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    xhr.addEventListener('load', () => {
+      if (xhr.status !== 200) {
+        reject(new Error(`HTTP ${xhr.status}: ${xhr.statusText}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(xhr.responseText) as TranslateResponse);
+      } catch {
+        reject(new Error('Invalid response from server'));
+      }
+    });
+
+    xhr.addEventListener('error', () => reject(new Error('Network error — could not reach server')));
+    xhr.addEventListener('abort', () => reject(new Error('Request was cancelled')));
+
+    xhr.open('POST', `${API_BASE_URL}/upload/`);
+    if (apiKey?.trim()) {
+      xhr.setRequestHeader('X-User-Api-Key', apiKey.trim());
     }
-
-    const result: TranslateResponse = await response.json();
-    return result;
-
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error';
-    throw new Error(`Failed to translate: ${errorMessage}`);
-  }
+    xhr.send(formData);
+  });
 }

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -571,6 +571,156 @@
   line-height: 1.5;
 }
 
+/* ── Loading State ── */
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.loading-icon-wrap {
+  font-size: 32px;
+  color: var(--accent);
+}
+
+.loading-icon-wrap.uploading {
+  animation: bounce-upload 1s ease-in-out infinite;
+}
+
+@keyframes bounce-upload {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+
+.loading-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.loading-subtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.loading-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.loading-dots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: dot-pulse 1.2s ease-in-out infinite;
+}
+
+.loading-dots span:nth-child(2) { animation-delay: 0.2s; }
+.loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes dot-pulse {
+  0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+.loading-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 280px;
+  text-align: left;
+}
+
+.loading-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.loading-step.done {
+  color: #16a34a;
+  font-weight: 500;
+}
+
+.loading-step.active {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.step-icon {
+  font-size: 16px;
+  width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.step-icon.spinning {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.loading-warning {
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: rgba(var(--accent-rgb, 99, 102, 241), 0.06);
+  border: 1px solid rgba(var(--accent-rgb, 99, 102, 241), 0.15);
+  border-radius: 8px;
+  padding: 12px 16px;
+  line-height: 1.6;
+  max-width: 300px;
+}
+
+.loading-warning strong {
+  color: var(--text-primary);
+}
+
+/* ── Insufficient Credits Error ── */
+.credits-error-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 18px;
+  border: 1px solid #fca5a5;
+  border-radius: 10px;
+  background: #fff5f5;
+}
+
+.credits-error-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #b91c1c;
+}
+
+.credits-error-body {
+  font-size: 13px;
+  color: #7f1d1d;
+  line-height: 1.6;
+}
+
+.credits-topup-link {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.credits-topup-link:hover {
+  text-decoration: underline;
+}
+
 .output-actions {
   display: flex;
   gap: 10px;

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -45,6 +45,30 @@ const TABS: { id: Tab; icon: any; label: string }[] = [
   { id: 'camera', icon: faCamera, label: 'Camera' },
 ];
 
+function isInsufficientCreditsError(msg: string) {
+  return /insufficient|credit|balance|402|payment required/i.test(msg);
+}
+
+function CreditsErrorCard() {
+  return (
+    <div className="credits-error-card">
+      <div className="credits-error-title">Insufficient Balance</div>
+      <div className="credits-error-body">
+        Your account does not have enough credits to process this request.
+        Please top up your OpenRouter account and try again.
+      </div>
+      <a
+        className="credits-topup-link"
+        href="https://openrouter.ai/credits"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Top up on OpenRouter →
+      </a>
+    </div>
+  );
+}
+
 export default function TranslatorPage() {
   const [activeTab, setActiveTab] = useState<Tab>('text');
   const [inputText, setInputText] = useState('');
@@ -57,9 +81,17 @@ export default function TranslatorPage() {
   const [selectedCameraId, setSelectedCameraId] = useState('');
   const [apiKey, setApiKey] = useState(() => localStorage.getItem('openrouter_api_key') ?? '');
   const [showApiKey, setShowApiKey] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [loadingPhase, setLoadingPhase] = useState<'idle' | 'uploading' | 'processing'>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [outputItems, setOutputItems] = useState<OutputItem[]>([]);
+  const loading = loadingPhase !== 'idle';
+  const [outputItems, setOutputItems] = useState<OutputItem[]>(() => {
+    try {
+      const saved = sessionStorage.getItem('ocr_output_items');
+      return saved ? JSON.parse(saved) : [];
+    } catch {
+      return [];
+    }
+  });
   const [copied, setCopied] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const cameraInputRef = useRef<HTMLInputElement | null>(null);
@@ -76,6 +108,14 @@ export default function TranslatorPage() {
   const supportsDeviceEnumeration =
     typeof navigator !== 'undefined' &&
     Boolean(navigator.mediaDevices?.enumerateDevices);
+
+  useEffect(() => {
+    if (outputItems.length > 0) {
+      sessionStorage.setItem('ocr_output_items', JSON.stringify(outputItems));
+    } else {
+      sessionStorage.removeItem('ocr_output_items');
+    }
+  }, [outputItems]);
 
   useEffect(() => {
     if (!cameraFile) {
@@ -749,7 +789,7 @@ const exportToDocx = async () => {
               className="btn-translate" 
               disabled={!hasInput || loading}
               onClick={async () => {
-                setLoading(true);
+                setLoadingPhase('uploading');
                 setError(null);
                 setOutputItems([]);
 
@@ -765,6 +805,7 @@ const exportToDocx = async () => {
                             ? [cameraFile]
                             : [],
                     apiKey: apiKey.trim() || undefined,
+                    onUploadDone: () => setLoadingPhase('processing'),
                   });
 
                   const formattedResults: OutputItem[] = Object.entries(result).map(
@@ -783,7 +824,7 @@ const exportToDocx = async () => {
                 } catch (err) {
                   setError(err instanceof Error ? err.message : 'Unknown error occurred');
                 } finally {
-                setLoading(false);
+                  setLoadingPhase('idle');
                 }
               }}
               >
@@ -820,24 +861,55 @@ const exportToDocx = async () => {
                 </button>
               </div>
             )}
-            {loading ? (
-              <div className="output-empty">
-                <div className="output-empty-icon">
-                  <FontAwesomeIcon icon={faFileLines} />
+            {loadingPhase === 'uploading' ? (
+              <div className="loading-state">
+                <div className="loading-icon-wrap uploading">
+                  <FontAwesomeIcon icon={faUpload} />
                 </div>
-                <div className="output-empty-text">Processing...</div>
+                <div className="loading-title">Uploading your files...</div>
+                <div className="loading-subtitle">Sending files to the server, please wait.</div>
+                <div className="loading-dots"><span /><span /><span /></div>
+              </div>
+            ) : loadingPhase === 'processing' ? (
+              <div className="loading-state">
+                <div className="loading-steps">
+                  <div className="loading-step done">
+                    <span className="step-icon">✓</span>
+                    <span>Upload complete</span>
+                  </div>
+                  {(activeTab === 'file' && selectedFiles.some(f => f.name.toLowerCase().endsWith('.zip'))) && (
+                    <div className="loading-step active">
+                      <span className="step-icon spinning">⟳</span>
+                      <span>Extracting archive...</span>
+                    </div>
+                  )}
+                  <div className="loading-step active">
+                    <span className="step-icon spinning">⟳</span>
+                    <span>AI is recognising text...</span>
+                  </div>
+                </div>
+                <div className="loading-warning">
+                  This may take <strong>1–3 minutes per page</strong>.<br />
+                  Please do not close or refresh this tab.
+                </div>
               </div>
             ) : error ? (
-              <div className="output-error">
-                {error}
-              </div>
+              isInsufficientCreditsError(error) ? (
+                <CreditsErrorCard />
+              ) : (
+                <div className="output-error">{error}</div>
+              )
             ) : outputItems.length > 0 ? (
               <div className="output-results">
                 {outputItems.map((item, index) => (
                   <div key={index} className="output-result-card">
                     <div className="output-file-name">{item.fileName}</div>
                     {item.error ? (
-                      <div className="output-error-text">Error: {item.error}</div>
+                      isInsufficientCreditsError(item.error) ? (
+                        <CreditsErrorCard />
+                      ) : (
+                        <div className="output-error-text">Error: {item.error}</div>
+                      )
                     ) : (
                       <pre className="output-text">{item.text}</pre>
                     )}


### PR DESCRIPTION
  - Skip macOS metadata files (__MACOSX/, ._*) in ZIP uploads to prevent false errors                                                                           
  - Handle null model response content with descriptive error message (finish_reason)                                                                           
  - Add upload progress states (uploading → processing) using XHR for real upload detection                                                                     
  - Show step-by-step loading UI so users know upload is done and AI is working                                                                                 
  - Persist OCR output to sessionStorage so results survive page navigation                                                                                     
  - Show dedicated insufficient credits error card with OpenRouter top-up link 