### PR TITLE
feat: implement Contact page (#41)

### DIFF
--- a/OCR-FRONTEND/package-lock.json
+++ b/OCR-FRONTEND/package-lock.json
@@ -13,6 +13,7 @@
         "docx": "^9.6.1",
         "file-saver": "^2.0.5",
         "jspdf": "^4.2.1",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.0"
@@ -21,6 +22,7 @@
         "@babel/core": "^7.29.0",
         "@eslint/js": "^9.39.4",
         "@rolldown/plugin-babel": "^0.2.1",
+        "@tailwindcss/vite": "^4.2.4",
         "@types/babel__core": "^7.20.5",
         "@types/file-saver": "^2.0.7",
         "@types/node": "^24.12.0",
@@ -32,6 +34,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "tailwindcss": "^4.2.4",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
@@ -965,6 +968,278 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
+      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "tailwindcss": "4.2.4"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1814,6 +2089,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2182,6 +2471,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2317,6 +2613,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2741,6 +3047,25 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -3242,6 +3567,27 @@
       "optional": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/text-segmentation": {

--- a/OCR-FRONTEND/package.json
+++ b/OCR-FRONTEND/package.json
@@ -15,6 +15,7 @@
     "docx": "^9.6.1",
     "file-saver": "^2.0.5",
     "jspdf": "^4.2.1",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.0"
@@ -23,6 +24,7 @@
     "@babel/core": "^7.29.0",
     "@eslint/js": "^9.39.4",
     "@rolldown/plugin-babel": "^0.2.1",
+    "@tailwindcss/vite": "^4.2.4",
     "@types/babel__core": "^7.20.5",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^24.12.0",
@@ -34,6 +36,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "tailwindcss": "^4.2.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1"

--- a/OCR-FRONTEND/src/index.css
+++ b/OCR-FRONTEND/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=DM+Sans:wght@300;400;500&display=swap');
+@import "tailwindcss";
 
 *, *::before, *::after {
   box-sizing: border-box;

--- a/OCR-FRONTEND/src/pages/ContactPage.tsx
+++ b/OCR-FRONTEND/src/pages/ContactPage.tsx
@@ -1,7 +1,273 @@
+import { useState, type FormEvent } from 'react';
+import { Mail, Phone, MapPin, Clock, Check } from 'lucide-react';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export default function ContactPage() {
+  const [name, setName]       = useState('');
+  const [email, setEmail]     = useState('');
+  const [subject, setSubject] = useState('');
+  const [message, setMessage] = useState('');
+  const [errors, setErrors]   = useState<Record<string, string>>({});
+  const [success, setSuccess] = useState(false);
+
+  const validate = (): boolean => {
+    const next: Record<string, string> = {};
+    if (!name.trim()) next.name = 'Name is required.';
+    const em = email.trim();
+    if (!em)                   next.email = 'Email is required.';
+    else if (!EMAIL_RE.test(em)) next.email = 'Please enter a valid email address.';
+    if (!message.trim()) next.message = 'Message is required.';
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (validate()) setSuccess(true);
+  };
+
+  const resetForm = () => {
+    setSuccess(false);
+    setName(''); setEmail(''); setSubject(''); setMessage(''); setErrors({});
+  };
+
+  const clearError = (key: string) =>
+    setErrors((prev) => { const n = { ...prev }; delete n[key]; return n; });
+
+  /* ── shared input style (visual only — no padding/margin) ── */
+  const inputCls = 'w-full bg-gray-100 border-0 rounded-xl text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-[#0f172a]';
+
+  const FAQS = [
+    {
+      q: 'What file formats do you support?',
+      a: 'We support JPEG, PNG, TIFF, BMP, and GIF files for individual uploads. For batch processing, upload a ZIP archive containing any of these image formats.',
+    },
+    {
+      q: 'Is there a file size limit?',
+      a: 'Yes, please keep individual image files under 10 MB for reliable processing. For batch uploads, compress your images into a ZIP archive.',
+    },
+    {
+      q: 'How accurate is the Fraktur transcription?',
+      a: 'Accuracy depends on scan quality and font clarity. Our primary model is Google Gemini (via OpenRouter), purpose-prompted for 1930s German Fraktur newspaper typography. We recommend reviewing all outputs before academic use.',
+    },
+    {
+      q: 'Can I edit the transcribed text before exporting?',
+      a: 'Yes, all transcription results are fully editable in the review panel before you export to PDF or Word.',
+    },
+    {
+      q: 'Which OCR model does Deciffer use?',
+      a: 'Deciffer currently uses Google Gemini (accessed via the OpenRouter API) as its primary OCR engine — a multimodal vision model prompted specifically for historical German Fraktur. A secondary pipeline based on Calamari 2 with a Fraktur-19th-century checkpoint (line-segmented by Kraken) is available for offline batch workflows.',
+    },
+  ];
+
   return (
-    <div className="page">
-      <div className="page-content" />
+    /* ── Page shell: pushes content below fixed 64 px navbar ── */
+    <div
+      className="bg-[#F4F6F9]"
+      style={{ minHeight: '100vh', paddingTop: '64px', paddingBottom: '80px' }}
+    >
+      {/* ── Centred container ── */}
+      <div style={{ maxWidth: '72rem', margin: '0 auto', padding: '0 2rem' }}>
+
+        {/* ── Section 1 · Header ── */}
+        <header className="text-center" style={{ padding: '3rem 0 2.5rem' }}>
+          <h1 className="text-4xl font-extrabold text-[#0f172a]">Contact Us</h1>
+          <p className="text-lg text-gray-500" style={{ marginTop: '0.75rem' }}>
+            Have questions? We&apos;d love to hear from you.
+          </p>
+        </header>
+
+        {/* ── Section 2 · Two-column layout ── */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '35% 1fr',
+            gap: '2rem',
+            alignItems: 'start',
+          }}
+        >
+          {/* ─── Left column · info cards ─── */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', minWidth: 0 }}>
+
+            {/* Email */}
+            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '1.5rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+                <div className="bg-gray-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
+                  <Mail size={20} className="text-[#0f172a]" />
+                </div>
+                <h3 className="font-bold text-[#0f172a]">Email</h3>
+              </div>
+              <p className="text-sm text-gray-500" style={{ wordBreak: 'break-all' }}>support@deciffer.com</p>
+              <p className="text-sm text-gray-500" style={{ marginTop: '0.25rem', wordBreak: 'break-all' }}>info@deciffer.com</p>
+            </div>
+
+            {/* Phone */}
+            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '1.5rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+                <div className="bg-gray-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
+                  <Phone size={20} className="text-[#0f172a]" />
+                </div>
+                <h3 className="font-bold text-[#0f172a]">Phone</h3>
+              </div>
+              <p className="text-sm text-gray-500">+49 (0) 123 456 789</p>
+              <p className="text-sm text-gray-500" style={{ marginTop: '0.25rem' }}>Mon–Fri, 9am–5pm CET</p>
+            </div>
+
+            {/* Office */}
+            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '1.5rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+                <div className="bg-gray-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
+                  <MapPin size={20} className="text-[#0f172a]" />
+                </div>
+                <h3 className="font-bold text-[#0f172a]">Office</h3>
+              </div>
+              <p className="text-sm text-gray-500">35 Stirling Hwy, Crawley WA 6009</p>
+              <p className="text-sm text-gray-500" style={{ marginTop: '0.25rem' }}>Perth, Australia</p>
+            </div>
+
+            {/* Support Hours */}
+            <div className="bg-blue-50 border border-blue-100 rounded-2xl shadow-sm" style={{ padding: '1.5rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
+                <div className="bg-blue-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
+                  <Clock size={20} className="text-[#0f172a]" />
+                </div>
+                <h3 className="font-bold text-[#0f172a]">Support Hours</h3>
+              </div>
+              <p className="text-sm text-gray-600">
+                <strong className="text-[#0f172a]">Monday – Friday:</strong> 9:00 AM – 5:00 PM
+              </p>
+              <p className="text-sm text-gray-600" style={{ marginTop: '0.35rem' }}>
+                <strong className="text-[#0f172a]">Saturday:</strong> 10:00 AM – 2:00 PM
+              </p>
+              <p className="text-sm text-gray-600" style={{ marginTop: '0.35rem' }}>
+                <strong className="text-[#0f172a]">Sunday:</strong> Closed
+              </p>
+            </div>
+          </div>
+
+          {/* ─── Right column · form + FAQ ─── */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+
+            {/* Contact Form card */}
+            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem' }}>
+              {success ? (
+                <div className="text-center" style={{ padding: '3rem 0' }}>
+                  <div
+                    className="inline-flex items-center justify-center rounded-full bg-green-100"
+                    style={{ padding: '0.75rem', marginBottom: '1rem' }}
+                  >
+                    <Check className="text-green-600" size={32} strokeWidth={2.5} aria-hidden />
+                  </div>
+                  <p className="font-semibold text-[#0f172a] text-lg">Message sent!</p>
+                  <p className="text-sm text-gray-500" style={{ marginTop: '0.5rem' }}>
+                    We&apos;ll get back to you within 24 hours.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={resetForm}
+                    className="text-sm font-medium text-[#0f172a] underline underline-offset-2 hover:text-[#1e293b] transition"
+                    style={{ marginTop: '1.5rem', display: 'block', margin: '1.5rem auto 0' }}
+                  >
+                    Send another message
+                  </button>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit} noValidate>
+
+                  {/* Row 1 · Name + Email */}
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+                    <div>
+                      <label htmlFor="contact-name" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                        Name *
+                      </label>
+                      <input
+                        id="contact-name" name="name" type="text" autoComplete="name"
+                        placeholder="Your name" value={name}
+                        onChange={(e) => { setName(e.target.value); if (errors.name) clearError('name'); }}
+                        className={inputCls} style={{ padding: '0.75rem 1rem' }}
+                      />
+                      {errors.name && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.name}</p>}
+                    </div>
+                    <div>
+                      <label htmlFor="contact-email" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                        Email *
+                      </label>
+                      <input
+                        id="contact-email" name="email" type="email" autoComplete="email"
+                        placeholder="your.email@example.com" value={email}
+                        onChange={(e) => { setEmail(e.target.value); if (errors.email) clearError('email'); }}
+                        className={inputCls} style={{ padding: '0.75rem 1rem' }}
+                      />
+                      {errors.email && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.email}</p>}
+                    </div>
+                  </div>
+
+                  {/* Row 2 · Subject */}
+                  <div style={{ marginTop: '1rem' }}>
+                    <label htmlFor="contact-subject" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                      Subject
+                    </label>
+                    <input
+                      id="contact-subject" name="subject" type="text"
+                      placeholder="What is this regarding?" value={subject}
+                      onChange={(e) => setSubject(e.target.value)}
+                      className={inputCls} style={{ padding: '0.75rem 1rem' }}
+                    />
+                  </div>
+
+                  {/* Row 3 · Message */}
+                  <div style={{ marginTop: '1rem' }}>
+                    <label htmlFor="contact-message" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                      Message *
+                    </label>
+                    <textarea
+                      id="contact-message" name="message" rows={6}
+                      placeholder="Tell us how we can help you..." value={message}
+                      onChange={(e) => { setMessage(e.target.value); if (errors.message) clearError('message'); }}
+                      className={`${inputCls} resize-y`}
+                      style={{ padding: '0.75rem 1rem', minHeight: '180px' }}
+                    />
+                    {errors.message && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.message}</p>}
+                  </div>
+
+                  {/* Submit */}
+                  <button
+                    type="submit"
+                    className="w-full bg-[#0f172a] text-white rounded-xl font-semibold text-sm hover:bg-[#1e293b] transition"
+                    style={{ padding: '0.75rem', marginTop: '1.5rem' }}
+                  >
+                    Send Message
+                  </button>
+                  <p className="text-xs text-gray-400 text-center" style={{ marginTop: '0.5rem' }}>
+                    * Required fields. We typically respond within 24 hours.
+                  </p>
+                </form>
+              )}
+            </div>
+
+            {/* FAQ card */}
+            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem' }}>
+              <h2 className="text-xl font-bold text-[#0f172a]" style={{ marginBottom: '1.5rem' }}>
+                Frequently Asked Questions
+              </h2>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {FAQS.map(({ q, a }, i) => (
+                  <li
+                    key={i}
+                    className={i < FAQS.length - 1 ? 'border-b border-gray-100' : ''}
+                    style={{ padding: i < FAQS.length - 1 ? '0 0 1rem' : '0', marginBottom: i < FAQS.length - 1 ? '1rem' : '0' }}
+                  >
+                    <p className="font-semibold text-[#0f172a] text-sm">{q}</p>
+                    <p className="text-gray-500 text-sm" style={{ marginTop: '0.25rem', lineHeight: '1.6' }}>{a}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+          </div>{/* end right column */}
+        </div>{/* end two-column grid */}
+      </div>{/* end centred container */}
     </div>
   );
 }

--- a/OCR-FRONTEND/vite.config.ts
+++ b/OCR-FRONTEND/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
+import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
+    tailwindcss(),
     react(),
     babel({ presets: [reactCompilerPreset()] })
   ],


### PR DESCRIPTION
## Summary

- Implements the full Contact page for issue #41
- Two-column layout: left info cards (Email, Phone, Office, Support Hours) + right contact form
- FAQ section with answers based on actual project tech stack 

## Changes

- **`OCR-FRONTEND/src/pages/ContactPage.tsx`** — complete rewrite from placeholder to full implementation:
  - Four contact info cards with lucide-react icons
  - Contact form (name / email / subject / message) with client-side validation, error hints, and success state
  - Office address: 35 Stirling Hwy, Crawley WA 6009 (UWA)
  - FAQ updated to reflect actual OCR pipeline (Google Gemini via OpenRouter as primary; Calamari 2 + Kraken as offline batch option)
  - Email overflow fix for narrow screens (`wordBreak: break-all` + `minWidth: 0`)
  - All spacing via inline styles to avoid Tailwind v4 cascade-layer conflict with the unlayered `* { margin:0; padding:0 }` reset in `index.css`

## Test plan

- [ ] Navigate to `/contact` — page renders with correct layout and `#F4F6F9` background
- [ ] Submit form with empty fields — red error hints appear under each required field
- [ ] Submit with invalid email — email-specific error shown
- [ ] Submit valid form — success state (green check + "Message sent!") appears
- [ ] Click "Send another message" — form resets
- [ ] Check Email card on narrow viewport — long addresses wrap without overflowing the card

Closes #41

