### PR TITLE
59 feature show original image preview alongside ocr output

### DIFF
--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -33,8 +33,12 @@ class GeminiOCRService:
         self.base_url = settings.OPENROUTER_BASE_URL
         self.url = f"{self.base_url}/chat/completions"
 
-    def recognise(self, file) -> str:
-
+    def recognise(self, file) -> tuple[str, str]:
+        """
+        Returns (recognised_text, preview_b64). The preview JPEG is the same
+        normalised image that was sent to Gemini, so the user sees exactly
+        what the model saw.
+        """
         # Reset file pointer
         file.seek(0)
 
@@ -89,4 +93,4 @@ class GeminiOCRService:
             finish_reason = choice.get('finish_reason', 'unknown')
             raise Exception(f"Model returned empty content (finish_reason: {finish_reason}).")
 
-        return content.strip()
+        return content.strip(), image_b64

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -142,12 +142,12 @@ class ImageUploadAndRecogniseView(View):
         # Process all collected images in parallel
         def recognise_task(name: str, file_bytes: bytes) -> tuple[str, dict]:
             try:
-                recognised_text = service.recognise(BytesIO(file_bytes))
-                return name, {"text": recognised_text}
+                text, preview_b64 = service.recognise(BytesIO(file_bytes))
+                return name, {"text": text, "preview_b64": preview_b64}
             except Exception as e:
                 return name, {"error": str(e)}
 
-        with ThreadPoolExecutor(max_workers=5) as executor:
+        with ThreadPoolExecutor(max_workers=10) as executor:
             futures = {executor.submit(recognise_task, name, data): name for name, data in tasks}
             for future in as_completed(futures):
                 name, result = future.result()

--- a/OCR-FRONTEND/package-lock.json
+++ b/OCR-FRONTEND/package-lock.json
@@ -2711,6 +2711,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",

--- a/OCR-FRONTEND/src/api.tsx
+++ b/OCR-FRONTEND/src/api.tsx
@@ -27,6 +27,7 @@ export interface TranslateResponse {
     text?: string;
     error?: string;
     status?: string;
+    preview_b64?: string;
   };
 }
 

--- a/OCR-FRONTEND/src/components/CreditsErrorCard.tsx
+++ b/OCR-FRONTEND/src/components/CreditsErrorCard.tsx
@@ -1,0 +1,23 @@
+export function isInsufficientCreditsError(msg: string) {
+  return /insufficient|credit|balance|402|payment required/i.test(msg);
+}
+
+export function CreditsErrorCard() {
+  return (
+    <div className="credits-error-card">
+      <div className="credits-error-title">Insufficient Balance</div>
+      <div className="credits-error-body">
+        Your account does not have enough credits to process this request.
+        Please top up your OpenRouter account and try again.
+      </div>
+      <a
+        className="credits-topup-link"
+        href="https://openrouter.ai/credits"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Top up on OpenRouter →
+      </a>
+    </div>
+  );
+}

--- a/OCR-FRONTEND/src/components/ResultView.css
+++ b/OCR-FRONTEND/src/components/ResultView.css
@@ -1,0 +1,154 @@
+.result-view {
+  width: 100%;
+}
+
+.result-view-actions-spacer {
+  flex: 1 1 auto;
+}
+
+.btn-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: #ffffff;
+  color: #374151;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.btn-back:hover {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+
+.result-view-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+  padding: 12px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.result-view-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #fff;
+  color: #374151;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  max-width: 280px;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.result-view-tab:hover {
+  border-color: #cbd5e1;
+  background: #f1f5f9;
+}
+
+.result-view-tab.active {
+  background: #3b82f6;
+  color: #fff;
+  border-color: #3b82f6;
+}
+
+.result-view-tab .tab-index {
+  font-weight: 600;
+  font-size: 12px;
+  opacity: 0.8;
+}
+
+.result-view-tab .tab-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result-view-tab .tab-error-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ef4444;
+  flex: 0 0 auto;
+}
+
+.result-view-panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  align-items: stretch;
+}
+
+.result-view-panels > .panel {
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 20px;
+  min-height: 400px;
+}
+
+.result-source-filename {
+  font-size: 13px;
+  color: #64748b;
+  margin-bottom: 12px;
+  word-break: break-all;
+}
+
+.result-source-link {
+  display: block;
+  overflow: hidden;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #f8fafc;
+  cursor: zoom-in;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.result-source-link:hover {
+  border-color: #94a3b8;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.result-source-link img {
+  display: block;
+  width: 100%;
+  max-height: 600px;
+  object-fit: contain;
+}
+
+.result-source-missing {
+  padding: 40px;
+  text-align: center;
+  color: #94a3b8;
+  border-radius: 10px;
+  background: #f8fafc;
+  border: 1px dashed #e5e7eb;
+}
+
+@media (max-width: 900px) {
+  .result-view-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .result-source-link img {
+    max-height: 420px;
+  }
+}

--- a/OCR-FRONTEND/src/components/ResultView.tsx
+++ b/OCR-FRONTEND/src/components/ResultView.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { CreditsErrorCard, isInsufficientCreditsError } from './CreditsErrorCard';
+import './ResultView.css';
+
+export type ResultItem = {
+  fileName: string;
+  text?: string;
+  error?: string;
+};
+
+type Props = {
+  items: ResultItem[];
+  previews: Record<string, string>;
+};
+
+export default function ResultView({ items, previews }: Props) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [items]);
+
+  if (items.length === 0) return null;
+
+  const safeIndex = Math.min(activeIndex, items.length - 1);
+  const active = items[safeIndex];
+  const activePreview = previews[active.fileName];
+
+  const renderOutput = () => {
+    if (active.error) {
+      return isInsufficientCreditsError(active.error) ? (
+        <CreditsErrorCard />
+      ) : (
+        <div className="output-error-text">Error: {active.error}</div>
+      );
+    }
+    return <pre className="output-text">{active.text}</pre>;
+  };
+
+  return (
+    <div className="result-view">
+      {items.length > 1 && (
+        <div className="result-view-tabs">
+          {items.map((item, i) => (
+            <button
+              key={item.fileName + i}
+              type="button"
+              onClick={() => setActiveIndex(i)}
+              className={`result-view-tab${i === safeIndex ? ' active' : ''}`}
+              title={item.fileName}
+            >
+              <span className="tab-index">{i + 1}</span>
+              <span className="tab-name">{item.fileName}</span>
+              {item.error && <span className="tab-error-dot" aria-label="error" />}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="result-view-panels">
+        <div className="panel result-source-panel">
+          <div className="panel-title">Source File</div>
+          <div className="result-source-filename">{active.fileName}</div>
+          {activePreview ? (
+            <a
+              className="result-source-link"
+              href={activePreview}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Open full size"
+            >
+              <img src={activePreview} alt={active.fileName} />
+            </a>
+          ) : (
+            <div className="result-source-missing">Preview not available</div>
+          )}
+        </div>
+
+        <div className="panel result-output-panel">
+          <div className="panel-title">Recognised Text</div>
+          {renderOutput()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/OCR-FRONTEND/src/components/ResultsSection.tsx
+++ b/OCR-FRONTEND/src/components/ResultsSection.tsx
@@ -1,0 +1,60 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faCopy,
+  faFilePdf,
+  faFileWord,
+  faEraser,
+  faArrowLeft,
+} from '@fortawesome/free-solid-svg-icons';
+import ResultView, { type ResultItem } from './ResultView';
+
+type Props = {
+  items: ResultItem[];
+  previews: Record<string, string>;
+  copied: boolean;
+  onBack: () => void;
+  onCopy: () => void;
+  onExportPdf: () => void;
+  onExportDocx: () => void;
+  onClear: () => void;
+};
+
+export default function ResultsSection({
+  items,
+  previews,
+  copied,
+  onBack,
+  onCopy,
+  onExportPdf,
+  onExportDocx,
+  onClear,
+}: Props) {
+  return (
+    <div className="result-view-container">
+      <div className="output-actions result-view-actions">
+        <button className="btn-back" type="button" onClick={onBack}>
+          <FontAwesomeIcon icon={faArrowLeft} />
+          Back to Input
+        </button>
+        <div className="result-view-actions-spacer" />
+        <button className="btn-export copy" onClick={onCopy}>
+          <FontAwesomeIcon icon={faCopy} />
+          {copied ? 'Copied!' : 'Copy Text'}
+        </button>
+        <button className="btn-export pdf" onClick={onExportPdf}>
+          <FontAwesomeIcon icon={faFilePdf} />
+          Download PDF
+        </button>
+        <button className="btn-export docx" onClick={onExportDocx}>
+          <FontAwesomeIcon icon={faFileWord} />
+          Download DOCX
+        </button>
+        <button className="btn-clear result-clear-btn" onClick={onClear}>
+          <FontAwesomeIcon icon={faEraser} />
+          New Translation
+        </button>
+      </div>
+      <ResultView items={items} previews={previews} />
+    </div>
+  );
+}

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -6,6 +6,38 @@
   flex-direction: column;
 }
 
+.view-results-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1e40af;
+  border-radius: 12px;
+  font-size: 14px;
+  flex-wrap: wrap;
+}
+
+.view-results-link {
+  background: transparent;
+  border: none;
+  color: #1d4ed8;
+  font-weight: 600;
+  font-family: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background 0.15s ease;
+}
+
+.view-results-link:hover {
+  background: #dbeafe;
+}
+
 .translator-container {
   max-width: 900px;
   margin: 0 auto;

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -11,6 +11,7 @@ import {
   HeadingLevel
 } from 'docx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import {
   faPenToSquare,
   faUpload,
@@ -20,54 +21,29 @@ import {
   faEraser,
   faLanguage,
   faFileLines,
-  faFilePdf,
-  faFileWord,
-  faCopy,
   faKey,
   faEye,
   faEyeSlash
 } from '@fortawesome/free-solid-svg-icons';
+import { type ResultItem } from '../components/ResultView';
+import ResultsSection from '../components/ResultsSection';
+import {
+  CreditsErrorCard,
+  isInsufficientCreditsError,
+} from '../components/CreditsErrorCard';
+import { extractPreviews } from '../utils/extractPreviews';
 
 type Tab = 'text' | 'file' | 'camera';
-type OutputItem = {
-  fileName: string;
-  text?: string;
-  error?: string;
-};
 type CameraOption = {
   deviceId: string;
   label: string;
 };
 
-const TABS: { id: Tab; icon: any; label: string }[] = [
+const TABS: { id: Tab; icon: IconDefinition; label: string }[] = [
   { id: 'text', icon: faPenToSquare, label: 'Text' },
   { id: 'file', icon: faUpload, label: 'File' },
   { id: 'camera', icon: faCamera, label: 'Camera' },
 ];
-
-function isInsufficientCreditsError(msg: string) {
-  return /insufficient|credit|balance|402|payment required/i.test(msg);
-}
-
-function CreditsErrorCard() {
-  return (
-    <div className="credits-error-card">
-      <div className="credits-error-title">Insufficient Balance</div>
-      <div className="credits-error-body">
-        Your account does not have enough credits to process this request.
-        Please top up your OpenRouter account and try again.
-      </div>
-      <a
-        className="credits-topup-link"
-        href="https://openrouter.ai/credits"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Top up on OpenRouter →
-      </a>
-    </div>
-  );
-}
 
 export default function TranslatorPage() {
   const [activeTab, setActiveTab] = useState<Tab>('text');
@@ -84,7 +60,7 @@ export default function TranslatorPage() {
   const [loadingPhase, setLoadingPhase] = useState<'idle' | 'uploading' | 'processing'>('idle');
   const [error, setError] = useState<string | null>(null);
   const loading = loadingPhase !== 'idle';
-  const [outputItems, setOutputItems] = useState<OutputItem[]>(() => {
+  const [outputItems, setOutputItems] = useState<ResultItem[]>(() => {
     try {
       const saved = sessionStorage.getItem('ocr_output_items');
       return saved ? JSON.parse(saved) : [];
@@ -92,6 +68,8 @@ export default function TranslatorPage() {
       return [];
     }
   });
+  const [filePreviews, setFilePreviews] = useState<Record<string, string>>({});
+  const [viewMode, setViewMode] = useState<'input' | 'results'>('input');
   const [copied, setCopied] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const cameraInputRef = useRef<HTMLInputElement | null>(null);
@@ -252,20 +230,6 @@ export default function TranslatorPage() {
     });
   };
 
-  const formatElapsedTime = (valueMs: number) => {
-    if (valueMs < 1000) {
-      return `${Math.max(0.1, valueMs / 1000).toFixed(1)} s`;
-    }
-
-    if (valueMs < 60000) {
-      return `${(valueMs / 1000).toFixed(1)} s`;
-    }
-
-    const minutes = Math.floor(valueMs / 60000);
-    const seconds = ((valueMs % 60000) / 1000).toFixed(1);
-    return `${minutes}m ${seconds}s`;
-  };
-
   useEffect(() => {
     if (!cameraActive || !videoRef.current || !streamRef.current) {
       return;
@@ -379,6 +343,8 @@ export default function TranslatorPage() {
     setCameraPreviewUrl(null);
     setCameraError(null);
     setOutputItems([]);
+    setFilePreviews({});
+    setViewMode('input');
     setCopied(false);
     setError(null);
     setProgressValue(0);
@@ -555,7 +521,7 @@ const copyOutputToClipboard = async () => {
     await navigator.clipboard.writeText(textToCopy);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
-  } catch (err) {
+  } catch {
     setError('Failed to copy output to clipboard.');
   }
 };
@@ -731,6 +697,33 @@ const exportToDocx = async () => {
         </div>
 
         {/* Side by side panel */}
+        {viewMode === 'results' && !loading && outputItems.length > 0 ? (
+          <ResultsSection
+            items={outputItems}
+            previews={filePreviews}
+            copied={copied}
+            onBack={() => setViewMode('input')}
+            onCopy={copyOutputToClipboard}
+            onExportPdf={exportToPDF}
+            onExportDocx={exportToDocx}
+            onClear={handleClear}
+          />
+        ) : (
+        <>
+        {!loading && outputItems.length > 0 && (
+          <div className="view-results-banner">
+            <span>
+              You have {outputItems.length} translated {outputItems.length === 1 ? 'file' : 'files'}.
+            </span>
+            <button
+              type="button"
+              className="view-results-link"
+              onClick={() => setViewMode('results')}
+            >
+              View results →
+            </button>
+          </div>
+        )}
         <div className="translator-panels">
 
           {/* Left — Input Panel */}
@@ -925,29 +918,32 @@ const exportToDocx = async () => {
                 setLoadingPhase('uploading');
                 setError(null);
                 setOutputItems([]);
+                setFilePreviews({});
                 setProgressValue(0);
                 setElapsedMs(0);
 
                 try {
+                  const uploadPayload: string | File[] =
+                    activeTab === 'text'
+                      ? inputText
+                      : activeTab === 'file'
+                        ? selectedFiles
+                        : cameraFile
+                          ? [cameraFile]
+                          : [];
+
                   const result = await handleTranslate({
                     type: activeTab === 'text' ? 'text' : 'file',
-                    data:
-                      activeTab === 'text'
-                        ? inputText
-                        : activeTab === 'file'
-                          ? selectedFiles
-                          : cameraFile
-                            ? [cameraFile]
-                            : [],
+                    data: uploadPayload,
                     apiKey: apiKey.trim() || undefined,
                     onUploadDone: () => setLoadingPhase('processing'),
                   });
 
-                  const formattedResults: OutputItem[] = Object.entries(result).map(
-                    ([fileName, value]: [string, any]) => ({
+                  const formattedResults: ResultItem[] = Object.entries(result).map(
+                    ([fileName, value]) => ({
                       fileName,
                       text: value?.text,
-                      error: value?.error
+                      error: value?.error,
                     })
                   );
 
@@ -957,6 +953,8 @@ const exportToDocx = async () => {
                     setError('No output received from server.');
                   } else {
                     setOutputItems(formattedResults);
+                    setFilePreviews(extractPreviews(result));
+                    setViewMode('results');
                   }
                 } catch (err) {
                   await finishProgressAnimation();
@@ -983,22 +981,6 @@ const exportToDocx = async () => {
           {/* Right — Output Panel */}
           <div className="panel output-panel">
             <div className="panel-title">Translation Output</div>
-            {outputItems.length > 0 && !loading && (
-              <div className="output-actions">
-                <button className="btn-export copy" onClick={copyOutputToClipboard}>
-                  <FontAwesomeIcon icon={faCopy} />
-                  {copied ? 'Copied!' : 'Copy Text'}
-                </button>
-                <button className="btn-export pdf" onClick={exportToPDF}>
-                  <FontAwesomeIcon icon={faFilePdf} />
-                  Download PDF
-                </button>
-                <button className="btn-export docx" onClick={exportToDocx}>
-                  <FontAwesomeIcon icon={faFileWord} />
-                  Download DOCX
-                </button>
-              </div>
-            )}
             {loadingPhase === 'uploading' ? (
               <div className="loading-state">
                 <div className="loading-icon-wrap uploading">
@@ -1015,12 +997,6 @@ const exportToDocx = async () => {
                     <span className="step-icon">✓</span>
                     <span>Upload complete</span>
                   </div>
-                  {(activeTab === 'file' && selectedFiles.some(f => f.name.toLowerCase().endsWith('.zip'))) && (
-                    <div className="loading-step active">
-                      <span className="step-icon spinning">⟳</span>
-                      <span>Extracting archive...</span>
-                    </div>
-                  )}
                   <div className="loading-step active">
                     <span className="step-icon spinning">⟳</span>
                     <span>AI is recognising text...</span>
@@ -1037,23 +1013,6 @@ const exportToDocx = async () => {
               ) : (
                 <div className="output-error">{error}</div>
               )
-            ) : outputItems.length > 0 ? (
-              <div className="output-results">
-                {outputItems.map((item, index) => (
-                  <div key={index} className="output-result-card">
-                    <div className="output-file-name">{item.fileName}</div>
-                    {item.error ? (
-                      isInsufficientCreditsError(item.error) ? (
-                        <CreditsErrorCard />
-                      ) : (
-                        <div className="output-error-text">Error: {item.error}</div>
-                      )
-                    ) : (
-                      <pre className="output-text">{item.text}</pre>
-                    )}
-                  </div>
-                ))}
-              </div>
             ) : (
               <div className="output-empty">
                 <div className="output-empty-icon">
@@ -1065,6 +1024,8 @@ const exportToDocx = async () => {
           </div>
 
         </div>
+        </>
+        )}
 
         {/* Supported Formats Bar */}
         <div className="formats-bar">

--- a/OCR-FRONTEND/src/utils/extractPreviews.ts
+++ b/OCR-FRONTEND/src/utils/extractPreviews.ts
@@ -1,0 +1,15 @@
+import type { TranslateResponse } from '../api';
+
+/**
+ * Turn a backend OCR response into a {fileName -> data URL} map
+ * using the base64 JPEG preview included for each file.
+ */
+export function extractPreviews(result: TranslateResponse): Record<string, string> {
+  const previews: Record<string, string> = {};
+  for (const [fileName, value] of Object.entries(result)) {
+    if (value?.preview_b64) {
+      previews[fileName] = `data:image/jpeg;base64,${value.preview_b64}`;
+    }
+  }
+  return previews;
+}


### PR DESCRIPTION
 ## Summary

  Researchers need to verify OCR accuracy against the original scan. Previously the translator showed only the recognised text; now the source image is displayed right next to its recognised output.

  ## Key changes

  **Backend**
  - `services.py` — `GeminiOCRService.recognise()` now returns `(text, preview_b64)`. The base64 JPEG already generated for Gemini is reused for display, so TIFFs, PNGs, and large scans all render correctly without any client-side conversion.
  - `views.py` — upload response includes `preview_b64` per file.

  **Frontend**
  - New `ResultView` component: file tabs on top, source image on the left, recognised text on the right. Handles 1-to-N files.
  - New `ResultsSection` component: wraps `ResultView` with the action bar (Copy / PDF / DOCX / Back / New Translation).
  - Non-destructive navigation via a `viewMode` state:
    - Translating succeeds → switches to results view
    - "Back to Input" preserves results and previews
    - Input view shows a banner to jump back to existing results
    - "New Translation" fully clears everything
  - `CreditsErrorCard` and `extractPreviews` extracted into their own files so `TranslatorPage` stays focused on input.
