### PR TITLE
Refine Calamari toggle behavior in translator page

### DIFF
--- a/OCR-FRONTEND/src/api.tsx
+++ b/OCR-FRONTEND/src/api.tsx
@@ -39,11 +39,13 @@ export function handleTranslate(params: {
   type: 'text' | 'file';
   data: string | File | File[];
   apiKey?: string;
+  engine?: 'gemini' | 'calamari';
   onUploadDone?: () => void;
 }): Promise<TranslateResponse> {
-  const { type, data, apiKey, onUploadDone } = params;
+  const { type, data, apiKey, engine = 'gemini', onUploadDone } = params;
 
   const formData = new FormData();
+  formData.append('engine', engine);
 
   // TEXT INPUT
   if (type === 'text' && typeof data === 'string') {
@@ -99,7 +101,7 @@ export function handleTranslate(params: {
       }
     });
 
-    xhr.addEventListener('error', () => reject(new Error('Network error — could not reach server')));
+    xhr.addEventListener('error', () => reject(new Error('Network error - could not reach server')));
     xhr.addEventListener('abort', () => reject(new Error('Request was cancelled')));
 
     xhr.open('POST', `${API_BASE_URL}/upload/`);

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -1,4 +1,4 @@
-/* ── Translator Page Shell ── */
+/* 鈹€鈹€ Translator Page Shell 鈹€鈹€ */
 .translator-page {
   padding-top: 64px;
   min-height: 100vh;
@@ -14,7 +14,7 @@
   flex: 1;
 }
 
-/* ── Header ── */
+/* 鈹€鈹€ Header 鈹€鈹€ */
 .translator-header {
   text-align: center;
   margin-bottom: 48px;
@@ -130,7 +130,7 @@
   }
 }
 
-/* ── Side-by-side Panels ── */
+/* 鈹€鈹€ Side-by-side Panels 鈹€鈹€ */
 .translator-container {
   max-width: 1200px;
   margin: 0 auto;
@@ -164,7 +164,7 @@
   margin-bottom: 20px;
 }
 
-/* ── Output Panel ── */
+/* 鈹€鈹€ Output Panel 鈹€鈹€ */
 .output-panel {
   min-height: 450px;
   display: flex;
@@ -267,7 +267,7 @@
   margin-bottom: 20px;
 }
 
-/* ── Tab Bar ── */
+/* 鈹€鈹€ Tab Bar 鈹€鈹€ */
 .tab-bar {
   display: flex;
   gap: 2px;
@@ -304,7 +304,7 @@
   color: #1a1a2e;
 }
 
-/* ── Text Input ── */
+/* 鈹€鈹€ Text Input 鈹€鈹€ */
 .input-label {
   font-size: 13px;
   font-weight: 500;
@@ -338,7 +338,7 @@
   background: #ffffff;
 }
 
-/* ── File Drop Zone ── */
+/* 鈹€鈹€ File Drop Zone 鈹€鈹€ */
 .file-drop-zone {
   border: 2px dashed #e5e7eb;
   border-radius: 10px;
@@ -543,7 +543,7 @@
 }
 
 
-/* ── Output Card ── */
+/* 鈹€鈹€ Output Card 鈹€鈹€ */
 .output-card {
   background: #ffffff;
   border: 1px solid #f3f4f6;
@@ -612,7 +612,7 @@
   line-height: 1.5;
 }
 
-/* ── Loading State ── */
+/* 鈹€鈹€ Loading State 鈹€鈹€ */
 .loading-state {
   display: flex;
   flex-direction: column;
@@ -727,7 +727,7 @@
   color: var(--text-primary);
 }
 
-/* ── Insufficient Credits Error ── */
+/* 鈹€鈹€ Insufficient Credits Error 鈹€鈹€ */
 .credits-error-card {
   display: flex;
   flex-direction: column;
@@ -795,7 +795,7 @@
   min-width: 110px;
 }
 
-/* ── Action Buttons ── */
+/* 鈹€鈹€ Action Buttons 鈹€鈹€ */
 .input-actions {
   display: flex;
   align-items: center;
@@ -855,7 +855,7 @@
   cursor: not-allowed;
 }
 
-/* ── Formats Bar ── */
+/* 鈹€鈹€ Formats Bar 鈹€鈹€ */
 .formats-bar {
   background: #ffffff;
   border: 1px solid #f3f4f6;
@@ -891,7 +891,7 @@
 }
 
 
-/* ── Responsive ── */
+/* 鈹€鈹€ Responsive 鈹€鈹€ */
 @media (max-width: 900px) {
   .translator-panels {
     grid-template-columns: 1fr;
@@ -944,4 +944,87 @@
 
 .api-key-status.empty {
   color: #9ca3af; /* grey */
+}
+
+.api-key-optional.disabled {
+  color: #9ca3af;
+}
+
+
+.translator-api-floating {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.translator-engine-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.translator-api-trigger,
+.translator-engine-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: #ffffff;
+  color: #374151;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s, background 0.2s, color 0.2s;
+}
+
+.translator-api-trigger:hover,
+.translator-engine-trigger:hover,
+.translator-api-trigger.open {
+  border-color: #cbd5e1;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+  transform: translateY(-1px);
+}
+
+.translator-engine-trigger.active {
+  background: #1a1a2e;
+  border-color: #1a1a2e;
+  color: #ffffff;
+}
+
+.translator-engine-trigger.active:hover {
+  border-color: #1a1a2e;
+  color: #ffffff;
+}
+
+.translator-engine-note {
+  max-width: 360px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #6b7280;
+  text-align: right;
+}
+
+.api-key-optional.disabled {
+  color: #9ca3af;
+}
+
+@media (max-width: 700px) {
+  .translator-api-floating {
+    align-items: center;
+  }
+
+  .translator-engine-controls {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .translator-engine-note {
+    text-align: center;
+    max-width: min(360px, calc(100vw - 40px));
+  }
 }

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -996,6 +996,10 @@
   gap: 12px;
 }
 
+.translator-engine-trigger-wrap {
+  position: relative;
+}
+
 .translator-api-trigger,
 .translator-engine-trigger {
   display: inline-flex;
@@ -1022,23 +1026,90 @@
   transform: translateY(-1px);
 }
 
-.translator-engine-trigger.active {
-  background: #1a1a2e;
-  border-color: #1a1a2e;
-  color: #ffffff;
+.translator-engine-trigger.mode-pill {
+  min-width: 148px;
+  width: 148px;
+  padding: 8px 10px;
+  justify-content: flex-start;
+  gap: 10px;
 }
 
-.translator-engine-trigger.active:hover {
-  border-color: #1a1a2e;
-  color: #ffffff;
+.translator-engine-trigger.mode-pill.mode-gemini {
+  background: #f0fdf4;
+  border-color: #86efac;
+  color: #166534;
 }
 
-.translator-engine-note {
-  max-width: 360px;
+.translator-engine-trigger.mode-pill.mode-calamari {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1e3a8a;
+}
+
+.engine-switch-track {
+  position: relative;
+  width: 34px;
+  height: 20px;
+  border-radius: 999px;
+  background: #bbf7d0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+  transition: background 0.2s ease;
+}
+
+.engine-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.translator-engine-trigger.mode-pill.mode-calamari .engine-switch-track {
+  background: #bfdbfe;
+}
+
+.translator-engine-trigger.mode-pill.mode-calamari .engine-switch-thumb {
+  transform: translateX(14px);
+}
+
+.translator-engine-trigger.mode-pill:hover {
+  transform: none;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+}
+
+.translator-engine-trigger.mode-pill:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 1px;
+}
+
+.translator-engine-tooltip {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(360px, calc(100vw - 40px));
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
   font-size: 12px;
   line-height: 1.55;
-  color: #6b7280;
-  text-align: right;
+  color: #475569;
+  text-align: left;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.16s ease, transform 0.16s ease;
+  pointer-events: none;
+  z-index: 40;
+}
+
+.translator-engine-trigger-wrap:hover .translator-engine-tooltip {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .api-key-optional.disabled {
@@ -1055,9 +1126,9 @@
     justify-content: center;
   }
 
-  .translator-engine-note {
-    text-align: center;
-    max-width: min(360px, calc(100vw - 40px));
+  .translator-engine-tooltip {
+    right: auto;
+    left: 0;
   }
 }
 

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -1,4 +1,4 @@
-/* 閳光偓閳光偓 Translator Page Shell 閳光偓閳光偓 */
+/*  Translator Page Shell  */
 .translator-page {
   padding-top: 64px;
   min-height: 100vh;
@@ -46,7 +46,7 @@
   flex: 1;
 }
 
-/* 閳光偓閳光偓 Header 閳光偓閳光偓 */
+/*  Header  */
 .translator-header {
   text-align: center;
   margin-bottom: 48px;
@@ -162,7 +162,7 @@
   }
 }
 
-/* 閳光偓閳光偓 Side-by-side Panels 閳光偓閳光偓 */
+/* Side-by-side Panels */
 .translator-container {
   max-width: 1200px;
   margin: 0 auto;
@@ -196,7 +196,7 @@
   margin-bottom: 20px;
 }
 
-/* 閳光偓閳光偓 Output Panel 閳光偓閳光偓 */
+/* Output Panel */
 .output-panel {
   min-height: 450px;
   display: flex;
@@ -299,7 +299,7 @@
   margin-bottom: 20px;
 }
 
-/* 閳光偓閳光偓 Tab Bar 閳光偓閳光偓 */
+/* Tab Bar */
 .tab-bar {
   display: flex;
   gap: 2px;
@@ -336,7 +336,7 @@
   color: #1a1a2e;
 }
 
-/* 閳光偓閳光偓 Text Input 閳光偓閳光偓 */
+/* Text Input */
 .input-label {
   font-size: 13px;
   font-weight: 500;
@@ -370,7 +370,7 @@
   background: #ffffff;
 }
 
-/* 閳光偓閳光偓 File Drop Zone 閳光偓閳光偓 */
+/* File Drop Zone */
 .file-drop-zone {
   border: 2px dashed #e5e7eb;
   border-radius: 10px;
@@ -759,7 +759,7 @@
   color: var(--text-primary);
 }
 
-/* 閳光偓閳光偓 Insufficient Credits Error 閳光偓閳光偓 */
+/* Insufficient Credits Error */
 .credits-error-card {
   display: flex;
   flex-direction: column;
@@ -827,7 +827,7 @@
   min-width: 110px;
 }
 
-/* 閳光偓閳光偓 Action Buttons 閳光偓閳光偓 */
+/* Action Buttons */
 .input-actions {
   display: flex;
   align-items: center;
@@ -887,7 +887,7 @@
   cursor: not-allowed;
 }
 
-/* 閳光偓閳光偓 Formats Bar 閳光偓閳光偓 */
+/* Formats Bar */
 .formats-bar {
   background: #ffffff;
   border: 1px solid #f3f4f6;
@@ -923,7 +923,7 @@
 }
 
 
-/* 閳光偓閳光偓 Responsive 閳光偓閳光偓 */
+/* Responsive */
 @media (max-width: 900px) {
   .translator-panels {
     grid-template-columns: 1fr;

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -575,7 +575,7 @@
 }
 
 
-/* 閳光偓閳光偓 Output Card 閳光偓閳光偓 */
+/*  Output Card  */
 .output-card {
   background: #ffffff;
   border: 1px solid #f3f4f6;
@@ -644,7 +644,7 @@
   line-height: 1.5;
 }
 
-/* 閳光偓閳光偓 Loading State 閳光偓閳光偓 */
+/*  Loading State  */
 .loading-state {
   display: flex;
   flex-direction: column;

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -1,4 +1,4 @@
-/* 鈹€鈹€ Translator Page Shell 鈹€鈹€ */
+/* 閳光偓閳光偓 Translator Page Shell 閳光偓閳光偓 */
 .translator-page {
   padding-top: 64px;
   min-height: 100vh;
@@ -14,7 +14,7 @@
   flex: 1;
 }
 
-/* 鈹€鈹€ Header 鈹€鈹€ */
+/* 閳光偓閳光偓 Header 閳光偓閳光偓 */
 .translator-header {
   text-align: center;
   margin-bottom: 48px;
@@ -130,7 +130,7 @@
   }
 }
 
-/* 鈹€鈹€ Side-by-side Panels 鈹€鈹€ */
+/* 閳光偓閳光偓 Side-by-side Panels 閳光偓閳光偓 */
 .translator-container {
   max-width: 1200px;
   margin: 0 auto;
@@ -164,7 +164,7 @@
   margin-bottom: 20px;
 }
 
-/* 鈹€鈹€ Output Panel 鈹€鈹€ */
+/* 閳光偓閳光偓 Output Panel 閳光偓閳光偓 */
 .output-panel {
   min-height: 450px;
   display: flex;
@@ -267,7 +267,7 @@
   margin-bottom: 20px;
 }
 
-/* 鈹€鈹€ Tab Bar 鈹€鈹€ */
+/* 閳光偓閳光偓 Tab Bar 閳光偓閳光偓 */
 .tab-bar {
   display: flex;
   gap: 2px;
@@ -304,7 +304,7 @@
   color: #1a1a2e;
 }
 
-/* 鈹€鈹€ Text Input 鈹€鈹€ */
+/* 閳光偓閳光偓 Text Input 閳光偓閳光偓 */
 .input-label {
   font-size: 13px;
   font-weight: 500;
@@ -338,7 +338,7 @@
   background: #ffffff;
 }
 
-/* 鈹€鈹€ File Drop Zone 鈹€鈹€ */
+/* 閳光偓閳光偓 File Drop Zone 閳光偓閳光偓 */
 .file-drop-zone {
   border: 2px dashed #e5e7eb;
   border-radius: 10px;
@@ -543,7 +543,7 @@
 }
 
 
-/* 鈹€鈹€ Output Card 鈹€鈹€ */
+/* 閳光偓閳光偓 Output Card 閳光偓閳光偓 */
 .output-card {
   background: #ffffff;
   border: 1px solid #f3f4f6;
@@ -612,7 +612,7 @@
   line-height: 1.5;
 }
 
-/* 鈹€鈹€ Loading State 鈹€鈹€ */
+/* 閳光偓閳光偓 Loading State 閳光偓閳光偓 */
 .loading-state {
   display: flex;
   flex-direction: column;
@@ -727,7 +727,7 @@
   color: var(--text-primary);
 }
 
-/* 鈹€鈹€ Insufficient Credits Error 鈹€鈹€ */
+/* 閳光偓閳光偓 Insufficient Credits Error 閳光偓閳光偓 */
 .credits-error-card {
   display: flex;
   flex-direction: column;
@@ -795,7 +795,7 @@
   min-width: 110px;
 }
 
-/* 鈹€鈹€ Action Buttons 鈹€鈹€ */
+/* 閳光偓閳光偓 Action Buttons 閳光偓閳光偓 */
 .input-actions {
   display: flex;
   align-items: center;
@@ -855,7 +855,7 @@
   cursor: not-allowed;
 }
 
-/* 鈹€鈹€ Formats Bar 鈹€鈹€ */
+/* 閳光偓閳光偓 Formats Bar 閳光偓閳光偓 */
 .formats-bar {
   background: #ffffff;
   border: 1px solid #f3f4f6;
@@ -891,7 +891,7 @@
 }
 
 
-/* 鈹€鈹€ Responsive 鈹€鈹€ */
+/* 閳光偓閳光偓 Responsive 閳光偓閳光偓 */
 @media (max-width: 900px) {
   .translator-panels {
     grid-template-columns: 1fr;
@@ -1027,4 +1027,47 @@
     text-align: center;
     max-width: min(360px, calc(100vw - 40px));
   }
+}
+
+.api-key-input-wrapper {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 10px;
+  row-gap: 8px;
+}
+
+.api-key-status {
+  grid-column: 1 / -1;
+  margin-top: 0;
+}
+
+.api-key-input {
+  width: 100%;
+  min-width: 0;
+}
+
+.api-key-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #374151;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.api-key-toggle:hover:not(:disabled) {
+  border-color: #1a1a2e;
+  color: #1a1a2e;
+}
+
+.api-key-toggle:disabled,
+.api-key-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -39,6 +39,8 @@ type CameraOption = {
   label: string;
 };
 
+type OcrEngine = 'gemini' | 'calamari';
+
 const TABS: { id: Tab; icon: any; label: string }[] = [
   { id: 'text', icon: faPenToSquare, label: 'Text' },
   { id: 'file', icon: faUpload, label: 'File' },
@@ -63,7 +65,7 @@ function CreditsErrorCard() {
         target="_blank"
         rel="noopener noreferrer"
       >
-        Top up on OpenRouter →
+        Top up on OpenRouter ->
       </a>
     </div>
   );
@@ -79,6 +81,7 @@ export default function TranslatorPage() {
   const [cameraActive, setCameraActive] = useState(false);
   const [cameraDevices, setCameraDevices] = useState<CameraOption[]>([]);
   const [selectedCameraId, setSelectedCameraId] = useState('');
+  const [ocrEngine, setOcrEngine] = useState<OcrEngine>('gemini');
   const [apiKey, setApiKey] = useState(() => localStorage.getItem('openrouter_api_key') ?? '');
   const [showApiKey, setShowApiKey] = useState(false);
   const [loadingPhase, setLoadingPhase] = useState<'idle' | 'uploading' | 'processing'>('idle');
@@ -658,6 +661,8 @@ const exportToDocx = async () => {
       : activeTab === 'file'
         ? selectedFiles.length > 0
         : Boolean(cameraFile);
+  const isCalamariMode = ocrEngine === 'calamari';
+  const engineDisplayName = isCalamariMode ? 'Calamari' : 'Gemini';
 
   return (
     <div className="translator-page">
@@ -670,21 +675,44 @@ const exportToDocx = async () => {
             Convert historical Fraktur font documents into readable modern German text
           </p>
           <div className="translator-api-floating" ref={apiPanelRef}>
-            <button
-              type="button"
-              className="translator-api-trigger"
-              onClick={() => setShowApiPanel((v) => !v)}
-              title="API key settings"
-            >
-              <FontAwesomeIcon icon={faKey} />
-              <span>API Key</span>
-            </button>
+            <div className="translator-engine-controls">
+              <button
+                type="button"
+                className={`translator-api-trigger${showApiPanel ? ' open' : ''}`}
+                onClick={() => setShowApiPanel((v) => !v)}
+                title="API key settings"
+              >
+                <FontAwesomeIcon icon={faKey} />
+                <span>API Key</span>
+              </button>
+
+              <button
+                type="button"
+                className={`translator-engine-trigger${isCalamariMode ? ' active' : ''}`}
+                onClick={() => {
+                  setOcrEngine((current) => current === 'calamari' ? 'gemini' : 'calamari');
+                  setShowApiPanel(false);
+                }}
+                title={isCalamariMode ? 'Switch back to Gemini mode' : 'Switch to Calamari mode'}
+              >
+                <FontAwesomeIcon icon={faFileLines} />
+                <span>Calamari</span>
+              </button>
+            </div>
+
+            {isCalamariMode && (
+              <div className="translator-engine-note">
+                Calamari does not consume tokens, but as a free model its OCR quality may be less ideal than Gemini.
+              </div>
+            )}
 
             {showApiPanel && (
               <div className="translator-api-popover">
                 <div className="translator-api-popover-header">
                   <div className="translator-api-popover-title">OpenRouter API Key</div>
-                  <span className="api-key-optional">optional</span>
+                  <span className={`api-key-optional${isCalamariMode ? ' disabled' : ''}`}>
+                    {isCalamariMode ? 'inactive in Calamari mode' : 'optional'}
+                  </span>
                 </div>
 
                 <div className="api-key-input-wrapper">
@@ -693,7 +721,9 @@ const exportToDocx = async () => {
                       apiKey.trim() ? 'saved' : 'empty'
                     }`}
                   >
-                    {apiKey.trim() ? 'Key saved in this browser' : 'No key saved'}
+                    {isCalamariMode
+                      ? (apiKey.trim() ? 'Saved, but not used in Calamari mode' : 'No key needed in Calamari mode')
+                      : (apiKey.trim() ? 'Key saved in this browser' : 'No key saved')}
                   </div>
                   <input
                     className="api-key-input"
@@ -711,19 +741,23 @@ const exportToDocx = async () => {
                     }}
                     autoComplete="off"
                     spellCheck={false}
+                    disabled={isCalamariMode}
                   />
                   <button
                     className="api-key-toggle"
                     type="button"
                     onClick={() => setShowApiKey((v) => !v)}
                     title={showApiKey ? 'Hide key' : 'Show key'}
+                    disabled={isCalamariMode}
                   >
                     <FontAwesomeIcon icon={showApiKey ? faEyeSlash : faEye} />
                   </button>
                 </div>
 
                 <p className="translator-api-popover-hint">
-                  Your key is sent per request and stored only in your browser. Clear it when using a shared computer.
+                  {isCalamariMode
+                    ? 'Calamari mode does not use an OpenRouter key. Switch back to Gemini when you want to use your own API key.'
+                    : 'Your key is sent per request and stored only in your browser. Clear it when using a shared computer.'}
                 </p>
               </div>
             )}
@@ -733,7 +767,7 @@ const exportToDocx = async () => {
         {/* Side by side panel */}
         <div className="translator-panels">
 
-          {/* Left — Input Panel */}
+          {/* Left Input Panel */}
           <div className="panel input-panel">
             <div className="panel-title">Input</div>
 
@@ -940,6 +974,7 @@ const exportToDocx = async () => {
                             ? [cameraFile]
                             : [],
                     apiKey: apiKey.trim() || undefined,
+                    engine: ocrEngine,
                     onUploadDone: () => setLoadingPhase('processing'),
                   });
 
@@ -967,7 +1002,7 @@ const exportToDocx = async () => {
               }}
               >
               <FontAwesomeIcon icon={faLanguage} />
-              {loading ? 'Processing...' : (activeTab === 'text' ? 'Translate' : 'Process & Translate')}
+              {loading ? `Processing with ${engineDisplayName}...` : (activeTab === 'text' ? 'Translate' : 'Process & Translate')}
               </button>
               <button
                 className="btn-clear"
@@ -980,7 +1015,7 @@ const exportToDocx = async () => {
             </div>
           </div>
 
-          {/* Right — Output Panel */}
+          {/* Right Output Panel */}
           <div className="panel output-panel">
             <div className="panel-title">Translation Output</div>
             {outputItems.length > 0 && !loading && (
@@ -1012,22 +1047,21 @@ const exportToDocx = async () => {
               <div className="loading-state">
                 <div className="loading-steps">
                   <div className="loading-step done">
-                    <span className="step-icon">✓</span>
+                    <span className="step-icon">OK</span>
                     <span>Upload complete</span>
                   </div>
                   {(activeTab === 'file' && selectedFiles.some(f => f.name.toLowerCase().endsWith('.zip'))) && (
                     <div className="loading-step active">
-                      <span className="step-icon spinning">⟳</span>
+                      <span className="step-icon spinning">...</span>
                       <span>Extracting archive...</span>
                     </div>
                   )}
                   <div className="loading-step active">
-                    <span className="step-icon spinning">⟳</span>
-                    <span>AI is recognising text...</span>
+                    <span className="step-icon spinning">...</span>
+                    <span>{isCalamariMode ? 'Calamari is recognising text...' : 'Gemini is recognising text...'}</span>
                   </div>
-                </div>
-                <div className="loading-warning">
-                  This may take <strong>1–3 minutes per page</strong>.<br />
+                </div>                <div className="loading-warning">
+                  This may take <strong>1-3 minutes per page</strong>.<br />
                   Please do not close or refresh this tab.
                 </div>
               </div>
@@ -1080,3 +1114,4 @@ const exportToDocx = async () => {
     </div>
   );
 }
+

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -629,6 +629,10 @@ const exportToDocx = async () => {
         : Boolean(cameraFile);
   const isCalamariMode = ocrEngine === 'calamari';
   const engineDisplayName = isCalamariMode ? 'Calamari' : 'Gemini';
+  const nextEngineDisplayName = isCalamariMode ? 'Gemini' : 'Calamari';
+  const engineHoverText = isCalamariMode
+    ? 'Using Calamari (free, no token usage). OCR quality can be lower than Gemini.'
+    : 'Using Gemini (best OCR quality, uses API credits/tokens).';
 
   return (
     <div className="translator-page">
@@ -659,25 +663,28 @@ const exportToDocx = async () => {
                 <span>API Key</span>
               </button>
 
-              <button
-                type="button"
-                className={`translator-engine-trigger${isCalamariMode ? ' active' : ''}`}
-                onClick={() => {
-                  setOcrEngine((current) => current === 'calamari' ? 'gemini' : 'calamari');
-                  setShowApiPanel(false);
-                }}
-                title={isCalamariMode ? 'Switch back to Gemini mode' : 'Switch to Calamari mode'}
-              >
-                <FontAwesomeIcon icon={faFileLines} />
-                <span>Calamari</span>
-              </button>
-            </div>
-
-            {isCalamariMode && (
-              <div className="translator-engine-note">
-                Calamari does not consume tokens, but as a free model its OCR quality may be less ideal than Gemini.
+              <div className="translator-engine-trigger-wrap">
+                <button
+                  type="button"
+                  className={`translator-engine-trigger mode-pill ${isCalamariMode ? 'mode-calamari' : 'mode-gemini'}`}
+                  onClick={() => {
+                    setOcrEngine((current) => current === 'calamari' ? 'gemini' : 'calamari');
+                    setShowApiPanel(false);
+                  }}
+                  role="switch"
+                  aria-checked={isCalamariMode}
+                  aria-label={`OCR engine is ${engineDisplayName}. Click to switch to ${nextEngineDisplayName}.`}
+                >
+                  <span className="engine-switch-track" aria-hidden="true">
+                    <span className="engine-switch-thumb" />
+                  </span>
+                  <span>{engineDisplayName}</span>
+                </button>
+                <div className="translator-engine-tooltip">
+                  {engineHoverText} Click to switch to {nextEngineDisplayName}.
+                </div>
               </div>
-            )}
+            </div>
 
             {showApiPanel && (
               <div className="translator-api-popover">

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -761,7 +761,7 @@ const exportToDocx = async () => {
               className="view-results-link"
               onClick={() => setViewMode('results')}
             >
-              View results 閳?
+              View results 闁?
             </button>
           </div>
         )}
@@ -818,6 +818,8 @@ const exportToDocx = async () => {
               ref={fileInputRef}
               type="file"
               id="file-input"
+              aria-label="Upload OCR source files"
+              title="Upload OCR source files"
               style={{ display: 'none' }}
               multiple
               onChange={(e) => handleFileChange(e.target.files)}
@@ -897,6 +899,8 @@ const exportToDocx = async () => {
                   type="file"
                   accept="image/*"
                   capture="environment"
+                  aria-label="Capture or upload a camera image"
+                  title="Capture or upload a camera image"
                   style={{ display: 'none' }}
                   onChange={(e) => handleCameraFileChange(e.target.files)}
                 />

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -679,7 +679,14 @@ const exportToDocx = async () => {
               <button
                 type="button"
                 className={`translator-api-trigger${showApiPanel ? ' open' : ''}`}
-                onClick={() => setShowApiPanel((v) => !v)}
+                onClick={() => {
+                  if (isCalamariMode) {
+                    setOcrEngine('gemini');
+                    setShowApiPanel(true);
+                    return;
+                  }
+                  setShowApiPanel((v) => !v);
+                }}
                 title="API key settings"
               >
                 <FontAwesomeIcon icon={faKey} />

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -761,7 +761,7 @@ const exportToDocx = async () => {
               className="view-results-link"
               onClick={() => setViewMode('results')}
             >
-              View results 闁?
+              View results →
             </button>
           </div>
         )}


### PR DESCRIPTION
## Summary
- add a Calamari toggle next to the API Key control on the translator page
- show a helper note when Calamari mode is active
- pass the selected OCR engine from the frontend request payload
- improve the API key input layout so the field uses the full row and the visibility toggle stays on the far right
- update the API Key button behavior so clicking it in Calamari mode switches back to Gemini mode

## Details
- Calamari mode is currently a frontend-only selection state
- the UI now makes the mode switch clearer and avoids getting stuck in Calamari when the user clicks API Key
- the OpenRouter API key input remains available for Gemini mode and is visually disabled in Calamari mode

## Scope
- frontend only
- no backend OCR pipeline changes in this PR
