### PR TITLE
fix(contact): remove unnecessary info cards and fix heading style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ Backend/ml_models/kraken_training/Data/
 Backend/ml_models/kraken_training/Outputs/
 
 
+
+.venv/

--- a/OCR-FRONTEND/src/pages/ContactPage.tsx
+++ b/OCR-FRONTEND/src/pages/ContactPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { Mail, Phone, MapPin, Clock, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -15,7 +15,7 @@ export default function ContactPage() {
     const next: Record<string, string> = {};
     if (!name.trim()) next.name = 'Name is required.';
     const em = email.trim();
-    if (!em)                   next.email = 'Email is required.';
+    if (!em)                     next.email = 'Email is required.';
     else if (!EMAIL_RE.test(em)) next.email = 'Please enter a valid email address.';
     if (!message.trim()) next.message = 'Message is required.';
     setErrors(next);
@@ -35,7 +35,6 @@ export default function ContactPage() {
   const clearError = (key: string) =>
     setErrors((prev) => { const n = { ...prev }; delete n[key]; return n; });
 
-  /* ── shared input style (visual only — no padding/margin) ── */
   const inputCls = 'w-full bg-gray-100 border-0 rounded-xl text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-[#0f172a]';
 
   const FAQS = [
@@ -62,212 +61,145 @@ export default function ContactPage() {
   ];
 
   return (
-    /* ── Page shell: pushes content below fixed 64 px navbar ── */
-    <div
-      className="bg-[#F4F6F9]"
-      style={{ minHeight: '100vh', paddingTop: '64px', paddingBottom: '80px' }}
-    >
-      {/* ── Centred container ── */}
-      <div style={{ maxWidth: '72rem', margin: '0 auto', padding: '0 2rem' }}>
+    <div className="bg-[#F4F6F9]" style={{ minHeight: '100vh', paddingTop: '64px', paddingBottom: '80px' }}>
+      <div style={{ maxWidth: '680px', margin: '0 auto', padding: '0 2rem' }}>
 
-        {/* ── Section 1 · Header ── */}
+        {/* Header */}
         <header className="text-center" style={{ padding: '3rem 0 2.5rem' }}>
-          <h1 className="text-4xl font-extrabold text-[#0f172a]">Contact Us</h1>
-          <p className="text-lg text-gray-500" style={{ marginTop: '0.75rem' }}>
+          <h1
+            style={{
+              fontFamily: "'Poppins', sans-serif",
+              fontSize: 'clamp(32px, 4vw, 48px)',
+              fontWeight: 700,
+              color: '#1a1a2e',
+              letterSpacing: '-0.02em',
+              marginBottom: '0.75rem',
+            }}
+          >
+            Contact Us
+          </h1>
+          <p className="text-lg text-gray-500">
             Have questions? We&apos;d love to hear from you.
           </p>
         </header>
 
-        {/* ── Section 2 · Two-column layout ── */}
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '35% 1fr',
-            gap: '2rem',
-            alignItems: 'start',
-          }}
-        >
-          {/* ─── Left column · info cards ─── */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', minWidth: 0 }}>
-
-            {/* Email */}
-            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '1.5rem' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
-                <div className="bg-gray-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
-                  <Mail size={20} className="text-[#0f172a]" />
-                </div>
-                <h3 className="font-bold text-[#0f172a]">Email</h3>
+        {/* Contact Form */}
+        <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem' }}>
+          {success ? (
+            <div className="text-center" style={{ padding: '3rem 0' }}>
+              <div
+                className="inline-flex items-center justify-center rounded-full bg-green-100"
+                style={{ padding: '0.75rem', marginBottom: '1rem' }}
+              >
+                <Check className="text-green-600" size={32} strokeWidth={2.5} aria-hidden />
               </div>
-              <p className="text-sm text-gray-500" style={{ wordBreak: 'break-all' }}>support@deciffer.com</p>
-              <p className="text-sm text-gray-500" style={{ marginTop: '0.25rem', wordBreak: 'break-all' }}>info@deciffer.com</p>
-            </div>
-
-            {/* Phone */}
-            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '1.5rem' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
-                <div className="bg-gray-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
-                  <Phone size={20} className="text-[#0f172a]" />
-                </div>
-                <h3 className="font-bold text-[#0f172a]">Phone</h3>
-              </div>
-              <p className="text-sm text-gray-500">+49 (0) 123 456 789</p>
-              <p className="text-sm text-gray-500" style={{ marginTop: '0.25rem' }}>Mon–Fri, 9am–5pm CET</p>
-            </div>
-
-            {/* Office */}
-            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '1.5rem' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
-                <div className="bg-gray-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
-                  <MapPin size={20} className="text-[#0f172a]" />
-                </div>
-                <h3 className="font-bold text-[#0f172a]">Office</h3>
-              </div>
-              <p className="text-sm text-gray-500">35 Stirling Hwy, Crawley WA 6009</p>
-              <p className="text-sm text-gray-500" style={{ marginTop: '0.25rem' }}>Perth, Australia</p>
-            </div>
-
-            {/* Support Hours */}
-            <div className="bg-blue-50 border border-blue-100 rounded-2xl shadow-sm" style={{ padding: '1.5rem' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
-                <div className="bg-blue-100 rounded-xl" style={{ padding: '0.5rem', display: 'inline-flex' }}>
-                  <Clock size={20} className="text-[#0f172a]" />
-                </div>
-                <h3 className="font-bold text-[#0f172a]">Support Hours</h3>
-              </div>
-              <p className="text-sm text-gray-600">
-                <strong className="text-[#0f172a]">Monday – Friday:</strong> 9:00 AM – 5:00 PM
+              <p className="font-semibold text-[#0f172a] text-lg">Message sent!</p>
+              <p className="text-sm text-gray-500" style={{ marginTop: '0.5rem' }}>
+                We&apos;ll get back to you within 24 hours.
               </p>
-              <p className="text-sm text-gray-600" style={{ marginTop: '0.35rem' }}>
-                <strong className="text-[#0f172a]">Saturday:</strong> 10:00 AM – 2:00 PM
-              </p>
-              <p className="text-sm text-gray-600" style={{ marginTop: '0.35rem' }}>
-                <strong className="text-[#0f172a]">Sunday:</strong> Closed
-              </p>
+              <button
+                type="button"
+                onClick={resetForm}
+                className="text-sm font-medium text-[#0f172a] underline underline-offset-2 hover:text-[#1e293b] transition"
+                style={{ marginTop: '1.5rem', display: 'block', margin: '1.5rem auto 0' }}
+              >
+                Send another message
+              </button>
             </div>
-          </div>
+          ) : (
+            <form onSubmit={handleSubmit} noValidate>
 
-          {/* ─── Right column · form + FAQ ─── */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-
-            {/* Contact Form card */}
-            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem' }}>
-              {success ? (
-                <div className="text-center" style={{ padding: '3rem 0' }}>
-                  <div
-                    className="inline-flex items-center justify-center rounded-full bg-green-100"
-                    style={{ padding: '0.75rem', marginBottom: '1rem' }}
-                  >
-                    <Check className="text-green-600" size={32} strokeWidth={2.5} aria-hidden />
-                  </div>
-                  <p className="font-semibold text-[#0f172a] text-lg">Message sent!</p>
-                  <p className="text-sm text-gray-500" style={{ marginTop: '0.5rem' }}>
-                    We&apos;ll get back to you within 24 hours.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={resetForm}
-                    className="text-sm font-medium text-[#0f172a] underline underline-offset-2 hover:text-[#1e293b] transition"
-                    style={{ marginTop: '1.5rem', display: 'block', margin: '1.5rem auto 0' }}
-                  >
-                    Send another message
-                  </button>
+              {/* Row 1 · Name + Email */}
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+                <div>
+                  <label htmlFor="contact-name" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                    Name *
+                  </label>
+                  <input
+                    id="contact-name" name="name" type="text" autoComplete="name"
+                    placeholder="Your name" value={name}
+                    onChange={(e) => { setName(e.target.value); if (errors.name) clearError('name'); }}
+                    className={inputCls} style={{ padding: '0.75rem 1rem' }}
+                  />
+                  {errors.name && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.name}</p>}
                 </div>
-              ) : (
-                <form onSubmit={handleSubmit} noValidate>
+                <div>
+                  <label htmlFor="contact-email" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                    Email *
+                  </label>
+                  <input
+                    id="contact-email" name="email" type="email" autoComplete="email"
+                    placeholder="your.email@example.com" value={email}
+                    onChange={(e) => { setEmail(e.target.value); if (errors.email) clearError('email'); }}
+                    className={inputCls} style={{ padding: '0.75rem 1rem' }}
+                  />
+                  {errors.email && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.email}</p>}
+                </div>
+              </div>
 
-                  {/* Row 1 · Name + Email */}
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-                    <div>
-                      <label htmlFor="contact-name" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                        Name *
-                      </label>
-                      <input
-                        id="contact-name" name="name" type="text" autoComplete="name"
-                        placeholder="Your name" value={name}
-                        onChange={(e) => { setName(e.target.value); if (errors.name) clearError('name'); }}
-                        className={inputCls} style={{ padding: '0.75rem 1rem' }}
-                      />
-                      {errors.name && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.name}</p>}
-                    </div>
-                    <div>
-                      <label htmlFor="contact-email" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                        Email *
-                      </label>
-                      <input
-                        id="contact-email" name="email" type="email" autoComplete="email"
-                        placeholder="your.email@example.com" value={email}
-                        onChange={(e) => { setEmail(e.target.value); if (errors.email) clearError('email'); }}
-                        className={inputCls} style={{ padding: '0.75rem 1rem' }}
-                      />
-                      {errors.email && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.email}</p>}
-                    </div>
-                  </div>
+              {/* Row 2 · Subject */}
+              <div style={{ marginTop: '1rem' }}>
+                <label htmlFor="contact-subject" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                  Subject
+                </label>
+                <input
+                  id="contact-subject" name="subject" type="text"
+                  placeholder="What is this regarding?" value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  className={inputCls} style={{ padding: '0.75rem 1rem' }}
+                />
+              </div>
 
-                  {/* Row 2 · Subject */}
-                  <div style={{ marginTop: '1rem' }}>
-                    <label htmlFor="contact-subject" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                      Subject
-                    </label>
-                    <input
-                      id="contact-subject" name="subject" type="text"
-                      placeholder="What is this regarding?" value={subject}
-                      onChange={(e) => setSubject(e.target.value)}
-                      className={inputCls} style={{ padding: '0.75rem 1rem' }}
-                    />
-                  </div>
+              {/* Row 3 · Message */}
+              <div style={{ marginTop: '1rem' }}>
+                <label htmlFor="contact-message" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
+                  Message *
+                </label>
+                <textarea
+                  id="contact-message" name="message" rows={6}
+                  placeholder="Tell us how we can help you..." value={message}
+                  onChange={(e) => { setMessage(e.target.value); if (errors.message) clearError('message'); }}
+                  className={`${inputCls} resize-y`}
+                  style={{ padding: '0.75rem 1rem', minHeight: '180px' }}
+                />
+                {errors.message && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.message}</p>}
+              </div>
 
-                  {/* Row 3 · Message */}
-                  <div style={{ marginTop: '1rem' }}>
-                    <label htmlFor="contact-message" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                      Message *
-                    </label>
-                    <textarea
-                      id="contact-message" name="message" rows={6}
-                      placeholder="Tell us how we can help you..." value={message}
-                      onChange={(e) => { setMessage(e.target.value); if (errors.message) clearError('message'); }}
-                      className={`${inputCls} resize-y`}
-                      style={{ padding: '0.75rem 1rem', minHeight: '180px' }}
-                    />
-                    {errors.message && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.message}</p>}
-                  </div>
+              {/* Submit */}
+              <button
+                type="submit"
+                className="w-full bg-[#0f172a] text-white rounded-xl font-semibold text-sm hover:bg-[#1e293b] transition"
+                style={{ padding: '0.75rem', marginTop: '1.5rem' }}
+              >
+                Send Message
+              </button>
+              <p className="text-xs text-gray-400 text-center" style={{ marginTop: '0.5rem' }}>
+                * Required fields. We typically respond within 24 hours.
+              </p>
+            </form>
+          )}
+        </div>
 
-                  {/* Submit */}
-                  <button
-                    type="submit"
-                    className="w-full bg-[#0f172a] text-white rounded-xl font-semibold text-sm hover:bg-[#1e293b] transition"
-                    style={{ padding: '0.75rem', marginTop: '1.5rem' }}
-                  >
-                    Send Message
-                  </button>
-                  <p className="text-xs text-gray-400 text-center" style={{ marginTop: '0.5rem' }}>
-                    * Required fields. We typically respond within 24 hours.
-                  </p>
-                </form>
-              )}
-            </div>
+        {/* FAQ card */}
+        <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem', marginTop: '2rem' }}>
+          <h2 className="text-xl font-bold text-[#0f172a]" style={{ marginBottom: '1.5rem' }}>
+            Frequently Asked Questions
+          </h2>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {FAQS.map(({ q, a }, i) => (
+              <li
+                key={i}
+                className={i < FAQS.length - 1 ? 'border-b border-gray-100' : ''}
+                style={{ padding: i < FAQS.length - 1 ? '0 0 1rem' : '0', marginBottom: i < FAQS.length - 1 ? '1rem' : '0' }}
+              >
+                <p className="font-semibold text-[#0f172a] text-sm">{q}</p>
+                <p className="text-gray-500 text-sm" style={{ marginTop: '0.25rem', lineHeight: '1.6' }}>{a}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
 
-            {/* FAQ card */}
-            <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem' }}>
-              <h2 className="text-xl font-bold text-[#0f172a]" style={{ marginBottom: '1.5rem' }}>
-                Frequently Asked Questions
-              </h2>
-              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-                {FAQS.map(({ q, a }, i) => (
-                  <li
-                    key={i}
-                    className={i < FAQS.length - 1 ? 'border-b border-gray-100' : ''}
-                    style={{ padding: i < FAQS.length - 1 ? '0 0 1rem' : '0', marginBottom: i < FAQS.length - 1 ? '1rem' : '0' }}
-                  >
-                    <p className="font-semibold text-[#0f172a] text-sm">{q}</p>
-                    <p className="text-gray-500 text-sm" style={{ marginTop: '0.25rem', lineHeight: '1.6' }}>{a}</p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-          </div>{/* end right column */}
-        </div>{/* end two-column grid */}
-      </div>{/* end centred container */}
+      </div>
     </div>
   );
 }

--- a/OCR-FRONTEND/src/pages/ContactPage.tsx
+++ b/OCR-FRONTEND/src/pages/ContactPage.tsx
@@ -1,205 +1,436 @@
-import { useState, type FormEvent } from 'react';
-import { Check } from 'lucide-react';
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { CheckCircle2, HelpCircle, Send } from 'lucide-react';
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+type ContactForm = {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+};
+
+type ContactErrors = Partial<Record<keyof ContactForm, string>>;
+
+const initialForm: ContactForm = {
+  name: '',
+  email: '',
+  subject: '',
+  message: '',
+};
+
+const faqItems = [
+  {
+    question: 'What should I include in a support message?',
+    answer:
+      'Include the input type, file format, OCR mode, and a short description of what went wrong.',
+  },
+  {
+    question: 'Can I report OCR quality issues?',
+    answer:
+      'Yes. Please describe the source scan and include the expected Fraktur text if you know it.',
+  },
+  {
+    question: 'Which OCR modes are supported?',
+    answer:
+      'The project currently supports Gemini API mode and is preparing a local Calamari-based workflow.',
+  },
+  {
+    question: 'Is my API key stored by the server?',
+    answer:
+      'No. User-supplied OpenRouter keys are sent per request and are not stored by the backend.',
+  },
+];
 
 export default function ContactPage() {
-  const [name, setName]       = useState('');
-  const [email, setEmail]     = useState('');
-  const [subject, setSubject] = useState('');
-  const [message, setMessage] = useState('');
-  const [errors, setErrors]   = useState<Record<string, string>>({});
-  const [success, setSuccess] = useState(false);
+  const [form, setForm] = useState<ContactForm>(initialForm);
+  const [errors, setErrors] = useState<ContactErrors>({});
+  const [submitted, setSubmitted] = useState(false);
 
-  const validate = (): boolean => {
-    const next: Record<string, string> = {};
-    if (!name.trim()) next.name = 'Name is required.';
-    const em = email.trim();
-    if (!em)                     next.email = 'Email is required.';
-    else if (!EMAIL_RE.test(em)) next.email = 'Please enter a valid email address.';
-    if (!message.trim()) next.message = 'Message is required.';
-    setErrors(next);
-    return Object.keys(next).length === 0;
+  const updateField = (field: keyof ContactForm, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setErrors((current) => ({ ...current, [field]: undefined }));
+    setSubmitted(false);
   };
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    if (validate()) setSuccess(true);
+  const validate = () => {
+    const nextErrors: ContactErrors = {};
+
+    if (!form.name.trim()) {
+      nextErrors.name = 'Name is required.';
+    }
+
+    if (!form.email.trim()) {
+      nextErrors.email = 'Email is required.';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
+      nextErrors.email = 'Enter a valid email address.';
+    }
+
+    if (!form.message.trim()) {
+      nextErrors.message = 'Message is required.';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
   };
 
-  const resetForm = () => {
-    setSuccess(false);
-    setName(''); setEmail(''); setSubject(''); setMessage(''); setErrors({});
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!validate()) {
+      return;
+    }
+
+    setSubmitted(true);
+    setForm(initialForm);
   };
-
-  const clearError = (key: string) =>
-    setErrors((prev) => { const n = { ...prev }; delete n[key]; return n; });
-
-  const inputCls = 'w-full bg-gray-100 border-0 rounded-xl text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-[#0f172a]';
-
-  const FAQS = [
-    {
-      q: 'What file formats do you support?',
-      a: 'We support JPEG, PNG, TIFF, BMP, and GIF files for individual uploads. For batch processing, upload a ZIP archive containing any of these image formats.',
-    },
-    {
-      q: 'Is there a file size limit?',
-      a: 'Yes, please keep individual image files under 10 MB for reliable processing. For batch uploads, compress your images into a ZIP archive.',
-    },
-    {
-      q: 'How accurate is the Fraktur transcription?',
-      a: 'Accuracy depends on scan quality and font clarity. Our primary model is Google Gemini (via OpenRouter), purpose-prompted for 1930s German Fraktur newspaper typography. We recommend reviewing all outputs before academic use.',
-    },
-    {
-      q: 'Can I edit the transcribed text before exporting?',
-      a: 'Yes, all transcription results are fully editable in the review panel before you export to PDF or Word.',
-    },
-    {
-      q: 'Which OCR model does Deciffer use?',
-      a: 'Deciffer currently uses Google Gemini (accessed via the OpenRouter API) as its primary OCR engine — a multimodal vision model prompted specifically for historical German Fraktur. A secondary pipeline based on Calamari 2 with a Fraktur-19th-century checkpoint (line-segmented by Kraken) is available for offline batch workflows.',
-    },
-  ];
 
   return (
-    <div className="bg-[#F4F6F9]" style={{ minHeight: '100vh', paddingTop: '64px', paddingBottom: '80px' }}>
-      <div style={{ maxWidth: '680px', margin: '0 auto', padding: '0 2rem' }}>
+    <main className="contact-page-shell">
+      <style>{`
+        .contact-page-shell {
+          min-height: calc(100vh - 88px);
+          background: #f4f6f9;
+          color: #17172a;
+          padding: 64px 28px 72px;
+        }
 
-        {/* Header */}
-        <header className="text-center" style={{ padding: '3rem 0 2.5rem' }}>
-          <h1
-            style={{
-              fontFamily: "'Poppins', sans-serif",
-              fontSize: 'clamp(32px, 4vw, 48px)',
-              fontWeight: 700,
-              color: '#1a1a2e',
-              letterSpacing: '-0.02em',
-              marginBottom: '0.75rem',
-            }}
-          >
-            Contact Us
-          </h1>
-          <p className="text-lg text-gray-500">
-            Have questions? We&apos;d love to hear from you.
+        .contact-page-inner {
+          width: min(1120px, 100%);
+          margin: 0 auto;
+        }
+
+        .contact-header {
+          text-align: center;
+          margin-bottom: 34px;
+        }
+
+        .contact-title {
+          margin: 0;
+          color: #17172a;
+          font-size: clamp(2.8rem, 4.2vw, 4.2rem);
+          line-height: 1;
+          letter-spacing: 0;
+        }
+
+        .contact-subtitle {
+          margin: 18px auto 0;
+          max-width: 640px;
+          color: #647086;
+          font-size: 1.15rem;
+          line-height: 1.65;
+        }
+
+        .contact-card {
+          border: 1px solid #dfe4ec;
+          border-radius: 8px;
+          background: #ffffff;
+          box-shadow: 0 18px 45px rgba(20, 24, 36, 0.08);
+          padding: 36px;
+        }
+
+        .contact-form {
+          display: grid;
+          gap: 22px;
+        }
+
+        .contact-form-grid {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 22px;
+        }
+
+        .contact-field {
+          display: grid;
+          gap: 8px;
+        }
+
+        .contact-field label {
+          color: #0d1326;
+          font-size: 0.96rem;
+          font-weight: 700;
+        }
+
+        .contact-field input,
+        .contact-field textarea {
+          width: 100%;
+          border: 1px solid #d9dee8;
+          border-radius: 8px;
+          background: #f8f9fb;
+          color: #17172a;
+          font: inherit;
+          font-size: 1rem;
+          outline: none;
+          transition: border-color 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
+        }
+
+        .contact-field input {
+          min-height: 56px;
+          padding: 0 18px;
+        }
+
+        .contact-field textarea {
+          min-height: 220px;
+          resize: vertical;
+          padding: 16px 18px;
+          line-height: 1.6;
+        }
+
+        .contact-field input:focus,
+        .contact-field textarea:focus {
+          border-color: #3b4558;
+          background: #ffffff;
+          box-shadow: 0 0 0 4px rgba(59, 69, 88, 0.12);
+        }
+
+        .contact-field input::placeholder,
+        .contact-field textarea::placeholder {
+          color: #96a0b2;
+        }
+
+        .contact-error {
+          color: #b42318;
+          font-size: 0.88rem;
+        }
+
+        .contact-submit-row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 18px;
+        }
+
+        .contact-submit-success {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          color: #26734d;
+          font-size: 0.95rem;
+          font-weight: 700;
+        }
+
+        .contact-submit-button {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          gap: 10px;
+          min-height: 50px;
+          border: 0;
+          border-radius: 8px;
+          padding: 0 24px;
+          background: #1b1209;
+          color: #ffffff;
+          font: inherit;
+          font-weight: 800;
+          cursor: pointer;
+          box-shadow: 0 14px 28px rgba(27, 18, 9, 0.18);
+          transition: transform 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
+        }
+
+        .contact-submit-button:hover {
+          background: #2b2118;
+          transform: translateY(-1px);
+          box-shadow: 0 18px 32px rgba(27, 18, 9, 0.22);
+        }
+
+        .contact-faq {
+          margin-top: 42px;
+        }
+
+        .contact-faq-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 24px;
+          margin-bottom: 18px;
+        }
+
+        .contact-faq-title {
+          margin: 0;
+          font-size: 1.55rem;
+          color: #17172a;
+        }
+
+        .contact-faq-note {
+          margin: 0;
+          color: #6a7487;
+          font-size: 0.98rem;
+        }
+
+        .contact-faq-grid {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 18px;
+        }
+
+        .contact-faq-item {
+          border: 1px solid #dfe4ec;
+          border-radius: 8px;
+          background: #ffffff;
+          padding: 22px;
+          box-shadow: 0 12px 30px rgba(20, 24, 36, 0.05);
+        }
+
+        .contact-faq-question {
+          display: flex;
+          align-items: flex-start;
+          gap: 10px;
+          margin: 0;
+          color: #17172a;
+          font-size: 1.02rem;
+          font-weight: 800;
+          line-height: 1.35;
+        }
+
+        .contact-faq-question svg {
+          flex: 0 0 auto;
+          margin-top: 1px;
+          color: #9a6f2f;
+        }
+
+        .contact-faq-answer {
+          margin: 10px 0 0 30px;
+          color: #5f6a7e;
+          line-height: 1.65;
+        }
+
+        @media (max-width: 760px) {
+          .contact-page-shell {
+            padding: 42px 18px 56px;
+          }
+
+          .contact-card {
+            padding: 24px;
+          }
+
+          .contact-form-grid,
+          .contact-faq-grid {
+            grid-template-columns: 1fr;
+          }
+
+          .contact-faq-header,
+          .contact-submit-row {
+            align-items: stretch;
+            flex-direction: column;
+          }
+
+          .contact-submit-button {
+            width: 100%;
+          }
+        }
+      `}</style>
+
+      <div className="contact-page-inner">
+        <header className="contact-header">
+          <h1 className="contact-title">Contact Us</h1>
+          <p className="contact-subtitle">
+            Have questions or feedback about the Fraktur OCR system? Send a message to the project team.
           </p>
         </header>
 
-        {/* Contact Form */}
-        <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem' }}>
-          {success ? (
-            <div className="text-center" style={{ padding: '3rem 0' }}>
-              <div
-                className="inline-flex items-center justify-center rounded-full bg-green-100"
-                style={{ padding: '0.75rem', marginBottom: '1rem' }}
-              >
-                <Check className="text-green-600" size={32} strokeWidth={2.5} aria-hidden />
+        <section className="contact-card" aria-label="Contact form">
+          <form className="contact-form" onSubmit={handleSubmit} noValidate>
+            <div className="contact-form-grid">
+              <div className="contact-field">
+                <label htmlFor="contact-name">Name *</label>
+                <input
+                  id="contact-name"
+                  value={form.name}
+                  onChange={(event) => updateField('name', event.target.value)}
+                  placeholder="Your name"
+                  aria-invalid={Boolean(errors.name)}
+                  aria-describedby={errors.name ? 'contact-name-error' : undefined}
+                />
+                {errors.name && (
+                  <span className="contact-error" id="contact-name-error">
+                    {errors.name}
+                  </span>
+                )}
               </div>
-              <p className="font-semibold text-[#0f172a] text-lg">Message sent!</p>
-              <p className="text-sm text-gray-500" style={{ marginTop: '0.5rem' }}>
-                We&apos;ll get back to you within 24 hours.
-              </p>
-              <button
-                type="button"
-                onClick={resetForm}
-                className="text-sm font-medium text-[#0f172a] underline underline-offset-2 hover:text-[#1e293b] transition"
-                style={{ marginTop: '1.5rem', display: 'block', margin: '1.5rem auto 0' }}
-              >
-                Send another message
+
+              <div className="contact-field">
+                <label htmlFor="contact-email">Email *</label>
+                <input
+                  id="contact-email"
+                  type="email"
+                  value={form.email}
+                  onChange={(event) => updateField('email', event.target.value)}
+                  placeholder="your.email@example.com"
+                  aria-invalid={Boolean(errors.email)}
+                  aria-describedby={errors.email ? 'contact-email-error' : undefined}
+                />
+                {errors.email && (
+                  <span className="contact-error" id="contact-email-error">
+                    {errors.email}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="contact-field">
+              <label htmlFor="contact-subject">Subject</label>
+              <input
+                id="contact-subject"
+                value={form.subject}
+                onChange={(event) => updateField('subject', event.target.value)}
+                placeholder="What is this regarding?"
+              />
+            </div>
+
+            <div className="contact-field">
+              <label htmlFor="contact-message">Message *</label>
+              <textarea
+                id="contact-message"
+                value={form.message}
+                onChange={(event) => updateField('message', event.target.value)}
+                placeholder="Tell us how we can help..."
+                aria-invalid={Boolean(errors.message)}
+                aria-describedby={errors.message ? 'contact-message-error' : undefined}
+              />
+              {errors.message && (
+                <span className="contact-error" id="contact-message-error">
+                  {errors.message}
+                </span>
+              )}
+            </div>
+
+            <div className="contact-submit-row">
+              {submitted ? (
+                <span className="contact-submit-success">
+                  <CheckCircle2 size={18} aria-hidden="true" />
+                  Message prepared successfully.
+                </span>
+              ) : (
+                <span />
+              )}
+              <button className="contact-submit-button" type="submit">
+                <Send size={18} aria-hidden="true" />
+                Send message
               </button>
             </div>
-          ) : (
-            <form onSubmit={handleSubmit} noValidate>
+          </form>
+        </section>
 
-              {/* Row 1 · Name + Email */}
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-                <div>
-                  <label htmlFor="contact-name" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                    Name *
-                  </label>
-                  <input
-                    id="contact-name" name="name" type="text" autoComplete="name"
-                    placeholder="Your name" value={name}
-                    onChange={(e) => { setName(e.target.value); if (errors.name) clearError('name'); }}
-                    className={inputCls} style={{ padding: '0.75rem 1rem' }}
-                  />
-                  {errors.name && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.name}</p>}
-                </div>
-                <div>
-                  <label htmlFor="contact-email" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                    Email *
-                  </label>
-                  <input
-                    id="contact-email" name="email" type="email" autoComplete="email"
-                    placeholder="your.email@example.com" value={email}
-                    onChange={(e) => { setEmail(e.target.value); if (errors.email) clearError('email'); }}
-                    className={inputCls} style={{ padding: '0.75rem 1rem' }}
-                  />
-                  {errors.email && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.email}</p>}
-                </div>
-              </div>
+        <section className="contact-faq" aria-labelledby="contact-faq-title">
+          <div className="contact-faq-header">
+            <h2 className="contact-faq-title" id="contact-faq-title">
+              Common Questions
+            </h2>
+            <p className="contact-faq-note">Useful context before sending a message.</p>
+          </div>
 
-              {/* Row 2 · Subject */}
-              <div style={{ marginTop: '1rem' }}>
-                <label htmlFor="contact-subject" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                  Subject
-                </label>
-                <input
-                  id="contact-subject" name="subject" type="text"
-                  placeholder="What is this regarding?" value={subject}
-                  onChange={(e) => setSubject(e.target.value)}
-                  className={inputCls} style={{ padding: '0.75rem 1rem' }}
-                />
-              </div>
-
-              {/* Row 3 · Message */}
-              <div style={{ marginTop: '1rem' }}>
-                <label htmlFor="contact-message" className="block text-sm font-medium text-[#0f172a]" style={{ marginBottom: '0.25rem' }}>
-                  Message *
-                </label>
-                <textarea
-                  id="contact-message" name="message" rows={6}
-                  placeholder="Tell us how we can help you..." value={message}
-                  onChange={(e) => { setMessage(e.target.value); if (errors.message) clearError('message'); }}
-                  className={`${inputCls} resize-y`}
-                  style={{ padding: '0.75rem 1rem', minHeight: '180px' }}
-                />
-                {errors.message && <p className="text-red-600 text-xs" style={{ marginTop: '0.375rem' }} role="alert">{errors.message}</p>}
-              </div>
-
-              {/* Submit */}
-              <button
-                type="submit"
-                className="w-full bg-[#0f172a] text-white rounded-xl font-semibold text-sm hover:bg-[#1e293b] transition"
-                style={{ padding: '0.75rem', marginTop: '1.5rem' }}
-              >
-                Send Message
-              </button>
-              <p className="text-xs text-gray-400 text-center" style={{ marginTop: '0.5rem' }}>
-                * Required fields. We typically respond within 24 hours.
-              </p>
-            </form>
-          )}
-        </div>
-
-        {/* FAQ card */}
-        <div className="bg-white rounded-2xl border border-gray-200 shadow-sm" style={{ padding: '2rem', marginTop: '2rem' }}>
-          <h2 className="text-xl font-bold text-[#0f172a]" style={{ marginBottom: '1.5rem' }}>
-            Frequently Asked Questions
-          </h2>
-          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-            {FAQS.map(({ q, a }, i) => (
-              <li
-                key={i}
-                className={i < FAQS.length - 1 ? 'border-b border-gray-100' : ''}
-                style={{ padding: i < FAQS.length - 1 ? '0 0 1rem' : '0', marginBottom: i < FAQS.length - 1 ? '1rem' : '0' }}
-              >
-                <p className="font-semibold text-[#0f172a] text-sm">{q}</p>
-                <p className="text-gray-500 text-sm" style={{ marginTop: '0.25rem', lineHeight: '1.6' }}>{a}</p>
-              </li>
+          <div className="contact-faq-grid">
+            {faqItems.map((item) => (
+              <article className="contact-faq-item" key={item.question}>
+                <h3 className="contact-faq-question">
+                  <HelpCircle size={20} aria-hidden="true" />
+                  {item.question}
+                </h3>
+                <p className="contact-faq-answer">{item.answer}</p>
+              </article>
             ))}
-          </ul>
-        </div>
-
+          </div>
+        </section>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

Resolves #57

- Remove Email, Phone, Office, and Office Hours info cards from the contact page
- Keep the contact form and FAQ section intact
- Fix the heading font style to match the site-wide design system (Poppins, font-weight 700, clamp(32px, 4vw, 48px))
- Simplify layout from a two-column grid to a single centered column

## Changes

- `OCR-FRONTEND/src/pages/ContactPage.tsx`
  - Remove unused icon imports: `Mail`, `Phone`, `MapPin`, `Clock`
  - Delete Email, Phone, Office, and Support Hours info cards
  - Fix `<h1>` heading style to match other pages
  - Simplify page layout to a single centered column (max-width 680px)
  - Retain contact form and FAQ section unchanged
