### PR TITLE
Testing and frontend bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __pycache__/
 !*.example
 venv/
 env/
+.venv/
 
 
 # ========================

--- a/Backend/src/ocrApp/tests.py
+++ b/Backend/src/ocrApp/tests.py
@@ -1,169 +1,219 @@
 import io
-import uuid
-from unittest.mock import patch
+import zipfile
+from unittest.mock import Mock, patch
 
-from django.test import TestCase, Client
+import requests
 from django.core.files.uploadedfile import SimpleUploadedFile
-
+from django.test import Client, TestCase
 from PIL import Image
 
-from .models import OCRImage
 
+def create_test_image(name="page.jpg", fmt="JPEG", content_type="image/jpeg"):
+    """Create a small valid image file for upload API tests."""
+    buffer = io.BytesIO()
+    Image.new("RGB", (50, 50), color="white").save(buffer, fmt)
+    buffer.seek(0)
 
-def _create_test_image(fmt="JPEG", ext="jpg", size=(100, 100)):
-    """Helper: generate a tiny in-memory image file."""
-    buf = io.BytesIO()
-    Image.new("RGB", size, color="white").save(buf, fmt)
-    buf.seek(0)
     return SimpleUploadedFile(
-        name=f"test_image.{ext}",
-        content=buf.read(),
-        content_type=f"image/{fmt.lower()}",
+        name=name,
+        content=buffer.read(),
+        content_type=content_type,
     )
 
 
-def _create_test_tif(size=(100, 100)):
-    """Helper: generate a tiny TIF image file."""
-    buf = io.BytesIO()
-    Image.new("RGB", size, color="white").save(buf, "TIFF")
-    buf.seek(0)
+def create_test_zip(name="pages.zip"):
+    """Create a ZIP containing one valid image file."""
+    image_buffer = io.BytesIO()
+    Image.new("RGB", (50, 50), color="white").save(image_buffer, "JPEG")
+    image_buffer.seek(0)
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as archive:
+        archive.writestr("page-001.jpg", image_buffer.read())
+    zip_buffer.seek(0)
+
     return SimpleUploadedFile(
-        name="test_image.tif",
-        content=buf.read(),
-        content_type="image/tiff",
+        name=name,
+        content=zip_buffer.read(),
+        content_type="application/zip",
     )
 
 
-# ---------------------------------------------------------------------------
-# Model tests
-# ---------------------------------------------------------------------------
-class OCRImageModelTest(TestCase):
-
-    def test_create_ocr_image(self):
-        """OCRImage can be created with default status 'pending'."""
-        img = OCRImage.objects.create(original_filename="sample.tif")
-        self.assertEqual(img.status, OCRImage.Status.PENDING)
-        self.assertEqual(str(img), "sample.tif (pending)")
-
-    def test_ordering_newest_first(self):
-        """Records are returned newest-first by default."""
-        a = OCRImage.objects.create(original_filename="a.tif")
-        b = OCRImage.objects.create(original_filename="b.tif")
-        records = list(OCRImage.objects.all())
-        self.assertEqual(records[0].id, b.id)
-
-
-# ---------------------------------------------------------------------------
-# Upload endpoint tests
-# ---------------------------------------------------------------------------
-class UploadEndpointTest(TestCase):
-
+class UploadApiTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.url = "/api/ocr/upload/"
 
-    @patch("ocrApp.services.GeminiOCRService.recognise")
-    def test_upload_jpg_success(self, mock_recognise):
-        """POST a JPEG image -> 200 with recognised text."""
-        mock_recognise.return_value = "Erkannter Text"
+    @patch("ocrApp.views.GeminiOCRService")
+    def test_upload_single_image_returns_mocked_ocr_result(self, mock_service_class):
+        mock_service = mock_service_class.return_value
+        mock_service.recognise.return_value = ("Mock OCR text", "mock_preview_base64")
 
-        image = _create_test_image()
-        response = self.client.post(self.url, {"image": image})
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(data["recognised_text"], "Erkannter Text")
-        self.assertEqual(data["status"], "completed")
-
-    @patch("ocrApp.services.GeminiOCRService.recognise")
-    def test_upload_tif_success(self, mock_recognise):
-        """POST a TIF image -> 200 (preprocessing converts to JPG)."""
-        mock_recognise.return_value = "Fraktur Text"
-
-        image = _create_test_tif()
-        response = self.client.post(self.url, {"image": image})
+        image = create_test_image()
+        response = self.client.post(self.url, {"images": [image]})
 
         self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(data["status"], "completed")
 
-    def test_upload_no_image_returns_400(self):
-        """POST without an image file -> 400."""
+        data = response.json()
+        self.assertIn("page.jpg", data)
+        self.assertEqual(data["page.jpg"]["text"], "Mock OCR text")
+        self.assertEqual(data["page.jpg"]["preview_b64"], "mock_preview_base64")
+        mock_service.recognise.assert_called_once()
+
+    @patch("ocrApp.views.GeminiOCRService")
+    def test_upload_multiple_images_returns_result_per_file(self, mock_service_class):
+        mock_service = mock_service_class.return_value
+        mock_service.recognise.return_value = ("Mock OCR text", "mock_preview_base64")
+
+        first_image = create_test_image(name="page-001.jpg")
+        second_image = create_test_image(name="page-002.jpg")
+        response = self.client.post(self.url, {"images": [first_image, second_image]})
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(set(data.keys()), {"page-001.jpg", "page-002.jpg"})
+        self.assertEqual(data["page-001.jpg"]["text"], "Mock OCR text")
+        self.assertEqual(data["page-002.jpg"]["preview_b64"], "mock_preview_base64")
+        self.assertEqual(mock_service.recognise.call_count, 2)
+
+    @patch("ocrApp.views.GeminiOCRService")
+    def test_upload_zip_extracts_image_and_returns_result(self, mock_service_class):
+        mock_service = mock_service_class.return_value
+        mock_service.recognise.return_value = ("ZIP OCR text", "zip_preview_base64")
+
+        archive = create_test_zip()
+        response = self.client.post(self.url, {"images": [archive]})
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertIn("page-001.jpg", data)
+        self.assertEqual(data["page-001.jpg"]["text"], "ZIP OCR text")
+        self.assertEqual(data["page-001.jpg"]["preview_b64"], "zip_preview_base64")
+
+    def test_upload_without_files_returns_400(self):
         response = self.client.post(self.url, {})
+
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "No files uploaded.")
 
-    def test_upload_invalid_file_type_returns_400(self):
-        """POST with a non-image file -> 400."""
-        txt = SimpleUploadedFile("notes.txt", b"hello", content_type="text/plain")
-        response = self.client.post(self.url, {"image": txt})
-        self.assertEqual(response.status_code, 400)
-
-    @patch("ocrApp.services.GeminiOCRService.recognise")
-    def test_upload_gemini_failure_returns_500(self, mock_recognise):
-        """If Gemini API fails, response status should be 'failed'."""
-        mock_recognise.side_effect = RuntimeError("API down")
-
-        image = _create_test_image()
-        response = self.client.post(self.url, {"image": image})
-
-        self.assertEqual(response.status_code, 500)
-        data = response.json()
-        self.assertEqual(data["status"], "failed")
-        self.assertIn("API down", data["error_message"])
-
-
-# ---------------------------------------------------------------------------
-# History endpoint tests
-# ---------------------------------------------------------------------------
-class HistoryEndpointTest(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-
-    def test_history_list_empty(self):
-        """GET /history/ returns an empty list when there are no records."""
-        response = self.client.get("/api/ocr/history/")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
-
-    def test_history_list_returns_records(self):
-        """GET /history/ returns existing OCR records."""
-        OCRImage.objects.create(original_filename="page1.tif")
-        OCRImage.objects.create(original_filename="page2.tif")
-
-        response = self.client.get("/api/ocr/history/")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()), 2)
-
-
-# ---------------------------------------------------------------------------
-# Result detail endpoint tests
-# ---------------------------------------------------------------------------
-class ResultDetailEndpointTest(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-
-    def test_get_result_detail(self):
-        """GET /result/<uuid>/ returns the full OCR record."""
-        record = OCRImage.objects.create(
-            original_filename="page.tif",
-            recognised_text="Hello",
-            status=OCRImage.Status.COMPLETED,
+    def test_upload_invalid_file_type_returns_per_file_error(self):
+        text_file = SimpleUploadedFile(
+            name="notes.txt",
+            content=b"not an image",
+            content_type="text/plain",
         )
-        response = self.client.get(f"/api/ocr/result/{record.id}/")
+
+        response = self.client.post(self.url, {"images": [text_file]})
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["recognised_text"], "Hello")
 
-    def test_get_nonexistent_result_returns_404(self):
-        """GET /result/<random-uuid>/ returns 404."""
-        fake_id = uuid.uuid4()
-        response = self.client.get(f"/api/ocr/result/{fake_id}/")
-        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertIn("notes.txt", data)
+        self.assertIn("error", data["notes.txt"])
 
-    def test_delete_result(self):
-        """DELETE /result/<uuid>/ removes the record."""
-        record = OCRImage.objects.create(original_filename="old.tif")
-        response = self.client.delete(f"/api/ocr/result/{record.id}/")
-        self.assertEqual(response.status_code, 204)
-        self.assertFalse(OCRImage.objects.filter(id=record.id).exists())
+    def test_invalid_user_api_key_returns_400(self):
+        image = create_test_image()
+
+        response = self.client.post(
+            self.url,
+            {"images": [image]},
+            HTTP_X_USER_API_KEY="invalid-key",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("invalid format", response.json()["error"])
+
+    @patch("ocrApp.views.GeminiOCRService")
+    def test_valid_user_api_key_is_passed_to_service(self, mock_service_class):
+        mock_service = mock_service_class.return_value
+        mock_service.recognise.return_value = ("Mock OCR text", "mock_preview_base64")
+        image = create_test_image()
+
+        response = self.client.post(
+            self.url,
+            {"images": [image]},
+            HTTP_X_USER_API_KEY="sk-or-v1-test123",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_service_class.assert_called_once_with(api_key="sk-or-v1-test123")
+
+    @patch("ocrApp.views.GeminiOCRService")
+    def test_ocr_service_failure_returns_per_file_error(self, mock_service_class):
+        mock_service = mock_service_class.return_value
+        mock_service.recognise.side_effect = RuntimeError("OpenRouter unavailable")
+        image = create_test_image()
+
+        response = self.client.post(self.url, {"images": [image]})
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertIn("page.jpg", data)
+        self.assertIn("OpenRouter unavailable", data["page.jpg"]["error"])
+
+
+class CreditsApiTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = "/api/ocr/credits/"
+
+    @patch("ocrApp.views.requests.get")
+    def test_credits_endpoint_returns_mocked_remaining_balance(self, mock_get):
+        fake_response = Mock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "data": {
+                "total_credits": 10,
+                "total_usage": 3.25,
+            }
+        }
+        mock_get.return_value = fake_response
+
+        response = self.client.get(
+            self.url,
+            HTTP_X_USER_API_KEY="sk-or-v1-test123",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(data["total_credits"], 10)
+        self.assertEqual(data["total_usage"], 3.25)
+        self.assertEqual(data["remaining"], 6.75)
+        mock_get.assert_called_once()
+
+    def test_credits_invalid_user_api_key_returns_400(self):
+        response = self.client.get(
+            self.url,
+            HTTP_X_USER_API_KEY="invalid-key",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("invalid format", response.json()["error"])
+
+    @patch("ocrApp.views.requests.get")
+    def test_credits_openrouter_failure_returns_502(self, mock_get):
+        mock_get.return_value.status_code = 500
+
+        response = self.client.get(
+            self.url,
+            HTTP_X_USER_API_KEY="sk-or-v1-test123",
+        )
+
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("OpenRouter returned 500", response.json()["error"])
+
+    @patch("ocrApp.views.requests.get")
+    def test_credits_network_error_returns_502(self, mock_get):
+        mock_get.side_effect = requests.RequestException("network down")
+
+        response = self.client.get(
+            self.url,
+            HTTP_X_USER_API_KEY="sk-or-v1-test123",
+        )
+
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("Failed to reach OpenRouter", response.json()["error"])

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -665,22 +665,41 @@ const exportToDocx = async () => {
               </button>
 
               <div className="translator-engine-trigger-wrap">
-                <button
-                  type="button"
-                  className={`translator-engine-trigger mode-pill ${isCalamariMode ? 'mode-calamari' : 'mode-gemini'}`}
-                  onClick={() => {
-                    setOcrEngine((current) => current === 'calamari' ? 'gemini' : 'calamari');
-                    setShowApiPanel(false);
-                  }}
-                  role="switch"
-                  aria-checked={isCalamariMode}
-                  aria-label={`OCR engine is ${engineDisplayName}. Click to switch to ${nextEngineDisplayName}.`}
-                >
-                  <span className="engine-switch-track" aria-hidden="true">
-                    <span className="engine-switch-thumb" />
-                  </span>
-                  <span>{engineDisplayName}</span>
-                </button>
+                {isCalamariMode ? (
+                  <button
+                    type="button"
+                    className="translator-engine-trigger mode-pill mode-calamari"
+                    onClick={() => {
+                      setOcrEngine('gemini');
+                      setShowApiPanel(false);
+                    }}
+                    role="switch"
+                    aria-checked="true"
+                    aria-label={`OCR engine is ${engineDisplayName}. Click to switch to ${nextEngineDisplayName}.`}
+                  >
+                    <span className="engine-switch-track" aria-hidden="true">
+                      <span className="engine-switch-thumb" />
+                    </span>
+                    <span>{engineDisplayName}</span>
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="translator-engine-trigger mode-pill mode-gemini"
+                    onClick={() => {
+                      setOcrEngine('calamari');
+                      setShowApiPanel(false);
+                    }}
+                    role="switch"
+                    aria-checked="false"
+                    aria-label={`OCR engine is ${engineDisplayName}. Click to switch to ${nextEngineDisplayName}.`}
+                  >
+                    <span className="engine-switch-track" aria-hidden="true">
+                      <span className="engine-switch-thumb" />
+                    </span>
+                    <span>{engineDisplayName}</span>
+                  </button>
+                )}
                 <div className="translator-engine-tooltip">
                   {engineHoverText} Click to switch to {nextEngineDisplayName}.
                 </div>


### PR DESCRIPTION
## Summary

This PR adds backend mock tests for the OCR API and fixes the ARIA state handling for the OCR engine switch on the Translator page.

## Changes

- Added updated Django test coverage for the current OCR backend API.
- Added mock-based tests for image upload, multi-file upload, ZIP upload, invalid file handling, API key validation, OCR service failure handling, and credits API behaviour.
- Mocked external Gemini/OpenRouter calls so tests do not consume API credits or depend on network availability.
- Fixed the OCR engine switch ARIA state by using explicit `aria-checked="true"` and `aria-checked="false"` values for Gemini/Calamari mode rendering.
<img width="870" height="264" alt="image" src="https://github.com/user-attachments/assets/36d3f1a8-aa29-48e3-bddb-0f47dd624947" />

- Added `.venv/` to `.gitignore` to prevent local Python virtual environments from being committed.

## Testing

Backend tests were run locally:


`python manage.py test ocrApp`

## Result:

Found 12 test(s).
Ran 12 tests.
OK
Notes
The tests focus on backend API behaviour and mocked external service responses. They do not test real Gemini/OpenRouter OCR accuracy or the full Kraken + Calamari local OCR pipeline.