### PR TITLE
Contact backend

### DIFF
--- a/Backend/src/OCR_Backend/settings.py
+++ b/Backend/src/OCR_Backend/settings.py
@@ -148,3 +148,14 @@ MEDIA_ROOT = BASE_DIR / 'media'
 OPENROUTER_API_KEY = os.environ.get('OPENROUTER_API_KEY', '')
 OPENROUTER_MODEL = os.environ.get('OPENROUTER_MODEL', "google/gemini-3.1-pro-preview")  # Default to a placeholder if not set
 OPENROUTER_BASE_URL = os.environ.get('OPENROUTER_BASE_URL', 'https://openrouter.ai/api/v1')
+
+# Email settings for Contact page notifications.
+# For Gmail, EMAIL_HOST_PASSWORD should be an app password, not the account password.
+EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend')
+EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.gmail.com')
+EMAIL_PORT = int(os.environ.get('EMAIL_PORT', '587'))
+EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'True') == 'True'
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER or 'webmaster@localhost')
+CONTACT_RECIPIENT_EMAIL = os.environ.get('CONTACT_RECIPIENT_EMAIL', 'deciffer.contact@gmail.com')

--- a/Backend/src/OCR_Backend/urls.py
+++ b/Backend/src/OCR_Backend/urls.py
@@ -16,9 +16,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from ocrApp.views import ContactMessageView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 
+    path('api/contact/', ContactMessageView.as_view(), name='contact'),
     path('api/ocr/', include('ocrApp.urls')),
 ]

--- a/Backend/src/ocrApp/admin.py
+++ b/Backend/src/ocrApp/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import OCRImage
+from .models import ContactMessage, OCRImage
 
 
 @admin.register(OCRImage)
@@ -8,4 +8,12 @@ class OCRImageAdmin(admin.ModelAdmin):
     list_filter = ("status",)
     search_fields = ("original_filename",)
     readonly_fields = ("id", "created_at", "updated_at")
+    ordering = ("-created_at",)
+
+
+@admin.register(ContactMessage)
+class ContactMessageAdmin(admin.ModelAdmin):
+    list_display = ("name", "email", "subject", "created_at")
+    search_fields = ("name", "email", "subject", "message")
+    readonly_fields = ("id", "created_at")
     ordering = ("-created_at",)

--- a/Backend/src/ocrApp/migrations/0001_initial.py
+++ b/Backend/src/ocrApp/migrations/0001_initial.py
@@ -1,0 +1,45 @@
+# Generated for OCR app initial database schema.
+
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="OCRImage",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("image", models.ImageField(upload_to="ocr_uploads/%Y/%m/%d/")),
+                ("original_filename", models.CharField(blank=True, max_length=255)),
+                ("recognised_text", models.TextField(blank=True, default="")),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("processing", "Processing"),
+                            ("completed", "Completed"),
+                            ("failed", "Failed"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("error_message", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "OCR Image",
+                "verbose_name_plural": "OCR Images",
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/Backend/src/ocrApp/migrations/0002_contactmessage.py
+++ b/Backend/src/ocrApp/migrations/0002_contactmessage.py
@@ -1,0 +1,31 @@
+# Generated for Contact page message storage.
+
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ocrApp", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ContactMessage",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("name", models.CharField(max_length=120)),
+                ("email", models.EmailField(max_length=254)),
+                ("subject", models.CharField(blank=True, default="", max_length=200)),
+                ("message", models.TextField()),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "verbose_name": "Contact Message",
+                "verbose_name_plural": "Contact Messages",
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/Backend/src/ocrApp/models.py
+++ b/Backend/src/ocrApp/models.py
@@ -37,3 +37,24 @@ class OCRImage(models.Model):
 
     def __str__(self):
         return f"{self.original_filename} ({self.status})"
+
+
+class ContactMessage(models.Model):
+    """
+    Stores messages submitted from the public Contact page.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=120)
+    email = models.EmailField()
+    subject = models.CharField(max_length=200, blank=True, default="")
+    message = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+        verbose_name = "Contact Message"
+        verbose_name_plural = "Contact Messages"
+
+    def __str__(self):
+        return f"{self.name} <{self.email}>"

--- a/Backend/src/ocrApp/tests.py
+++ b/Backend/src/ocrApp/tests.py
@@ -1,4 +1,5 @@
 import io
+import json
 import zipfile
 from unittest.mock import Mock, patch
 
@@ -6,6 +7,8 @@ import requests
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, TestCase
 from PIL import Image
+
+from .models import ContactMessage
 
 
 def create_test_image(name="page.jpg", fmt="JPEG", content_type="image/jpeg"):
@@ -217,3 +220,102 @@ class CreditsApiTests(TestCase):
 
         self.assertEqual(response.status_code, 502)
         self.assertIn("Failed to reach OpenRouter", response.json()["error"])
+
+
+class ContactMessageApiTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = "/api/contact/"
+
+    @patch("ocrApp.views.send_mail")
+    def test_contact_message_success_creates_record_and_sends_email(self, mock_send_mail):
+        payload = {
+            "name": "Research User",
+            "email": "researcher@example.com",
+            "subject": "OCR feedback",
+            "message": "The OCR output needs review for one Fraktur scan.",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(ContactMessage.objects.count(), 1)
+
+        message = ContactMessage.objects.get()
+        self.assertEqual(message.name, payload["name"])
+        self.assertEqual(message.email, payload["email"])
+        self.assertEqual(message.subject, payload["subject"])
+        self.assertEqual(message.message, payload["message"])
+
+        data = response.json()
+        self.assertEqual(data["name"], payload["name"])
+        self.assertEqual(data["email"], payload["email"])
+        mock_send_mail.assert_called_once()
+        self.assertEqual(mock_send_mail.call_args.kwargs["recipient_list"], ["deciffer.contact@gmail.com"])
+
+    def test_contact_message_required_fields_return_400(self):
+        response = self.client.post(
+            self.url,
+            data=json.dumps({"subject": "Missing required fields"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(ContactMessage.objects.count(), 0)
+
+        errors = response.json()["errors"]
+        self.assertIn("name", errors)
+        self.assertIn("email", errors)
+        self.assertIn("message", errors)
+
+    def test_contact_message_invalid_email_returns_400(self):
+        payload = {
+            "name": "Research User",
+            "email": "not-an-email",
+            "message": "Please check this OCR result.",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(ContactMessage.objects.count(), 0)
+        self.assertIn("email", response.json()["errors"])
+
+    def test_contact_message_invalid_json_returns_400(self):
+        response = self.client.post(
+            self.url,
+            data="{invalid json",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(ContactMessage.objects.count(), 0)
+        self.assertEqual(response.json()["error"], "Invalid JSON body.")
+
+    @patch("ocrApp.views.send_mail")
+    def test_contact_message_email_failure_returns_502(self, mock_send_mail):
+        mock_send_mail.side_effect = RuntimeError("SMTP unavailable")
+        payload = {
+            "name": "Research User",
+            "email": "researcher@example.com",
+            "subject": "OCR feedback",
+            "message": "The OCR output needs review for one Fraktur scan.",
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(ContactMessage.objects.count(), 1)
+        self.assertIn("email notification could not be sent", response.json()["error"])

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -3,16 +3,21 @@ import zipfile
 import tempfile
 import os
 import logging
+import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import BytesIO
 
 import requests
 from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.mail import send_mail
+from django.core.validators import validate_email
 from django.http import JsonResponse, Http404
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 
+from .models import ContactMessage
 from .serializers import (
     ALLOWED_IMAGE_TYPES,
     serialize_ocr_result,
@@ -44,6 +49,98 @@ def _validate_user_api_key(raw: str | None) -> tuple[str | None, str | None]:
         return None, "Provided API key has an invalid format."
 
     return raw, None
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class ContactMessageView(View):
+    """
+    POST /api/contact/
+    Store a Contact page message after server-side validation.
+    """
+
+    def post(self, request):
+        try:
+            payload = json.loads(request.body.decode("utf-8") or "{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"error": "Invalid JSON body."}, status=400)
+
+        name = str(payload.get("name", "")).strip()
+        email = str(payload.get("email", "")).strip()
+        subject = str(payload.get("subject", "")).strip()
+        message = str(payload.get("message", "")).strip()
+
+        errors = {}
+
+        if not name:
+            errors["name"] = "Name is required."
+        elif len(name) > 120:
+            errors["name"] = "Name must be 120 characters or fewer."
+
+        if not email:
+            errors["email"] = "Email is required."
+        else:
+            try:
+                validate_email(email)
+            except ValidationError:
+                errors["email"] = "Enter a valid email address."
+
+        if len(subject) > 200:
+            errors["subject"] = "Subject must be 200 characters or fewer."
+
+        if not message:
+            errors["message"] = "Message is required."
+
+        if errors:
+            return JsonResponse({"errors": errors}, status=400)
+
+        contact_message = ContactMessage.objects.create(
+            name=name,
+            email=email,
+            subject=subject,
+            message=message,
+        )
+
+        email_subject = subject or "New Deciffer contact message"
+        email_subject = " ".join(email_subject.splitlines())
+        email_body = (
+            "A new message was submitted from the Deciffer Contact page.\n\n"
+            f"Name: {name}\n"
+            f"Email: {email}\n"
+            f"Subject: {subject or '(No subject)'}\n\n"
+            "Message:\n"
+            f"{message}\n\n"
+            f"Saved message ID: {contact_message.id}"
+        )
+
+        try:
+            send_mail(
+                subject=email_subject,
+                message=email_body,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[settings.CONTACT_RECIPIENT_EMAIL],
+                fail_silently=False,
+            )
+        except Exception as exc:
+            logger.exception("Failed to send contact message notification email.")
+            return JsonResponse(
+                {
+                    "error": "Message was saved, but the email notification could not be sent.",
+                    "id": str(contact_message.id),
+                },
+                status=502,
+            )
+
+        return JsonResponse(
+            {
+                "id": str(contact_message.id),
+                "name": contact_message.name,
+                "email": contact_message.email,
+                "subject": contact_message.subject,
+                "message": contact_message.message,
+                "created_at": contact_message.created_at.isoformat(),
+            },
+            status=201,
+        )
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/OCR-FRONTEND/src/api.tsx
+++ b/OCR-FRONTEND/src/api.tsx
@@ -1,5 +1,6 @@
 // API Configuration
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/ocr';
+const API_ROOT_URL = API_BASE_URL.replace(/\/ocr\/?$/, '');
 
 export interface CreditsResponse {
   total_credits: number;
@@ -29,6 +30,64 @@ export interface TranslateResponse {
     status?: string;
     preview_b64?: string;
   };
+}
+
+export interface ContactPayload {
+  name: string;
+  email: string;
+  subject?: string;
+  message: string;
+}
+
+export interface ContactResponse {
+  id: string;
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+  created_at: string;
+}
+
+export type ContactFieldErrors = Partial<Record<keyof ContactPayload, string>>;
+
+export class ContactApiError extends Error {
+  status: number;
+  fieldErrors?: ContactFieldErrors;
+
+  constructor(message: string, status: number, fieldErrors?: ContactFieldErrors) {
+    super(message);
+    this.name = 'ContactApiError';
+    this.status = status;
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+export async function submitContactMessage(payload: ContactPayload): Promise<ContactResponse> {
+  const response = await fetch(`${API_ROOT_URL}/contact/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  let responseBody: unknown = null;
+  try {
+    responseBody = await response.json();
+  } catch {
+    responseBody = null;
+  }
+
+  if (!response.ok) {
+    const body = responseBody as { error?: string; errors?: ContactFieldErrors } | null;
+    throw new ContactApiError(
+      body?.error || 'Failed to submit contact message.',
+      response.status,
+      body?.errors
+    );
+  }
+
+  return responseBody as ContactResponse;
 }
 
 /**

--- a/OCR-FRONTEND/src/pages/ContactPage.tsx
+++ b/OCR-FRONTEND/src/pages/ContactPage.tsx
@@ -143,6 +143,24 @@ export default function ContactPage() {
           font-weight: 300;
         }
 
+        .contact-email-note {
+          margin: 14px auto 0;
+          color: #4b5563;
+          font-size: 15px;
+          line-height: 1.6;
+          font-weight: 300;
+        }
+
+        .contact-email-note a {
+          color: #1a1a2e;
+          font-weight: 700;
+          text-decoration: none;
+        }
+
+        .contact-email-note a:hover {
+          text-decoration: underline;
+        }
+
         .contact-card {
           border: 1px solid #dfe4ec;
           border-radius: 8px;
@@ -360,6 +378,10 @@ export default function ContactPage() {
           <h1 className="contact-title">Contact Us</h1>
           <p className="contact-subtitle">
             Have questions or feedback about the Fraktur OCR system? Send a message to the project team.
+          </p>
+          <p className="contact-email-note">
+            You can also contact us directly at{' '}
+            <a href="mailto:deciffer.contact@gmail.com">deciffer.contact@gmail.com</a>.
           </p>
         </header>
 

--- a/OCR-FRONTEND/src/pages/ContactPage.tsx
+++ b/OCR-FRONTEND/src/pages/ContactPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { FormEvent } from 'react';
 import { CheckCircle2, HelpCircle, Send } from 'lucide-react';
+import { ContactApiError, submitContactMessage } from '../api';
 
 type ContactForm = {
   name: string;
@@ -45,11 +46,14 @@ export default function ContactPage() {
   const [form, setForm] = useState<ContactForm>(initialForm);
   const [errors, setErrors] = useState<ContactErrors>({});
   const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const updateField = (field: keyof ContactForm, value: string) => {
     setForm((current) => ({ ...current, [field]: value }));
     setErrors((current) => ({ ...current, [field]: undefined }));
     setSubmitted(false);
+    setSubmitError(null);
   };
 
   const validate = () => {
@@ -73,15 +77,32 @@ export default function ContactPage() {
     return Object.keys(nextErrors).length === 0;
   };
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (!validate()) {
       return;
     }
 
-    setSubmitted(true);
-    setForm(initialForm);
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      await submitContactMessage(form);
+      setSubmitted(true);
+      setForm(initialForm);
+    } catch (error) {
+      if (error instanceof ContactApiError) {
+        if (error.fieldErrors) {
+          setErrors(error.fieldErrors);
+        }
+        setSubmitError(error.message);
+      } else {
+        setSubmitError('Network error. Please try again later.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -192,6 +213,12 @@ export default function ContactPage() {
           font-size: 0.88rem;
         }
 
+        .contact-submit-error {
+          color: #b42318;
+          font-size: 0.95rem;
+          font-weight: 700;
+        }
+
         .contact-submit-row {
           display: flex;
           align-items: center;
@@ -224,6 +251,13 @@ export default function ContactPage() {
           cursor: pointer;
           box-shadow: 0 14px 28px rgba(27, 18, 9, 0.18);
           transition: transform 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
+        }
+
+        .contact-submit-button:disabled {
+          cursor: not-allowed;
+          opacity: 0.68;
+          transform: none;
+          box-shadow: none;
         }
 
         .contact-submit-button:hover {
@@ -397,14 +431,16 @@ export default function ContactPage() {
               {submitted ? (
                 <span className="contact-submit-success">
                   <CheckCircle2 size={18} aria-hidden="true" />
-                  Message prepared successfully.
+                  Message sent successfully.
                 </span>
+              ) : submitError ? (
+                <span className="contact-submit-error">{submitError}</span>
               ) : (
                 <span />
               )}
-              <button className="contact-submit-button" type="submit">
+              <button className="contact-submit-button" type="submit" disabled={submitting}>
                 <Send size={18} aria-hidden="true" />
-                Send message
+                {submitting ? 'Sending...' : 'Send message'}
               </button>
             </div>
           </form>

--- a/OCR-FRONTEND/src/pages/ContactPage.tsx
+++ b/OCR-FRONTEND/src/pages/ContactPage.tsx
@@ -122,23 +122,25 @@ export default function ContactPage() {
 
         .contact-header {
           text-align: center;
-          margin-bottom: 34px;
+          margin-bottom: 40px;
         }
 
         .contact-title {
           margin: 0;
           color: #17172a;
-          font-size: clamp(2.8rem, 4.2vw, 4.2rem);
-          line-height: 1;
-          letter-spacing: 0;
+          font-size: clamp(32px, 4vw, 48px);
+          line-height: 1.1;
+          letter-spacing: -0.02em;
+          font-weight: 700;
         }
 
         .contact-subtitle {
-          margin: 18px auto 0;
+          margin: 12px auto 0;
           max-width: 640px;
-          color: #647086;
-          font-size: 1.15rem;
-          line-height: 1.65;
+          color: #6b7280;
+          font-size: 16px;
+          line-height: 1.6;
+          font-weight: 300;
         }
 
         .contact-card {

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ OPENROUTER_API_KEY=your_openrouter_api_key
 OPENROUTER_MODEL=google/gemini-3.1-pro-preview
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
+# Contact form email notification
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_HOST_USER=deciffer.contact@gmail.com
+EMAIL_HOST_PASSWORD=your_gmail_app_password
+DEFAULT_FROM_EMAIL=deciffer.contact@gmail.com
+CONTACT_RECIPIENT_EMAIL=deciffer.contact@gmail.com
+
 ```
 ### Running the Backend with Docker
 


### PR DESCRIPTION
## Summary

This PR implements backend support for the Contact page and connects the frontend Contact form to the new API endpoint.

It also updates the Contact page UI so users can either submit the form or contact the project team directly at `deciffer.contact@gmail.com`.

## Changes

### Backend

- Added a `ContactMessage` model to store submitted contact messages.
- Added database migrations for the contact message table.
- Registered contact messages in Django admin.
- Added `POST /api/contact/` endpoint.
- Added server-side validation for required fields:
  - `name`
  - `email`
  - `message`
- Added email format validation for submitted email addresses.
- Saves valid messages to the database.
- Sends contact message notifications to `deciffer.contact@gmail.com`.
- Added email-related environment configuration in Django settings.
- Added backend tests for contact message submission, validation errors, invalid JSON, and email notification failure.

### Frontend

- Connected the Contact page form to the backend API.
- Added a contact API client in `api.tsx`.
- Displays server-side validation errors.
- Displays network/server submission errors.
- Shows a success message after successful submission.
- Added a direct email note:
  `You can also contact us directly at deciffer.contact@gmail.com.`
- Adjusted the Contact page header sizing to better match the About and How It Works pages.

### Documentation

- Updated README environment variable examples for contact email notification settings.

## Testing

Manual testing completed:

- Submitted a valid Contact form message.
- Confirmed the message is saved successfully.
- Confirmed email notification is sent to `deciffer.contact@gmail.com`.
<img width="1015" height="571" alt="image" src="https://github.com/user-attachments/assets/ba793dc8-8f68-4b3e-a05d-ff66204a6862" />
- Confirmed invalid form data is handled by validation.

Recommended backend test command:

```bash
python manage.py test ocrApp
