### PR TITLE
Clean up Translator page (TSX + CSS)

### DIFF
--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -1178,3 +1178,50 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.translator-panels-single {
+  grid-template-columns: 1fr;
+}
+
+.translator-panels-single .input-panel {
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.processing-banner {
+  max-width: 900px;
+  margin: 0 auto 18px;
+  padding: 16px 20px;
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.processing-banner.error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.processing-spinner {
+  width: 18px;
+  height: 18px;
+  border: 3px solid #bfdbfe;
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation: processing-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes processing-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -200,90 +200,6 @@
   margin-bottom: 20px;
 }
 
-/* Output Panel */
-.output-panel {
-  min-height: 450px;
-  display: flex;
-  flex-direction: column;
-}
-
-.output-empty {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 60px 0;
-}
-
-.output-empty-icon {
-  font-size: 40px;
-  color: #d1d5db;
-}
-
-.output-empty-text {
-  font-size: 14px;
-  color: #9ca3af;
-  font-weight: 300;
-}
-
-.progress-card {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 16px;
-  padding: 28px 8px;
-}
-
-.progress-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.progress-card-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: #1a1a2e;
-}
-
-.progress-card-percent {
-  font-size: 18px;
-  font-weight: 700;
-  color: #1a1a2e;
-}
-
-.progress-track {
-  position: relative;
-  width: 100%;
-  height: 12px;
-  background: #e5e7eb;
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.progress-fill {
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(90deg, #1a1a2e 0%, #3f3c68 100%);
-  transition: width 0.18s ease-out;
-}
-
-.progress-card-meta {
-  font-size: 14px;
-  font-weight: 500;
-  color: #4b5563;
-}
-
-.progress-card-hint {
-  font-size: 14px;
-  line-height: 1.6;
-  color: #6b7280;
-}
-
 
 .input-card {
   background: #ffffff;
@@ -578,191 +494,6 @@
   color: #6b7280;
 }
 
-
-/*  Output Card  */
-.output-card {
-  background: #ffffff;
-  border: 1px solid #f3f4f6;
-  border-radius: 16px;
-  padding: 28px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.06), 0 4px 12px rgba(0,0,0,0.04);
-  margin-bottom: 20px;
-  min-height: 200px;
-  display: flex;
-  flex-direction: column;
-}
-
-.output-card-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: #6b7280;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  margin-bottom: 20px;
-}
-
-.output-results {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  margin-top: 4px;
-  max-height: 360px;
-  overflow-y: auto;
-}
-
-.output-result-card {
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  padding: 14px;
-}
-
-.output-file-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: #1a1a2e;
-  margin-bottom: 10px;
-  word-break: break-word;
-}
-
-.output-text {
-  margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-family: 'Poppins', sans-serif;
-  font-size: 14px;
-  line-height: 1.6;
-  color: #374151;
-}
-
-.output-error {
-  color: #b91c1c;
-  font-size: 14px;
-  font-weight: 500;
-  padding: 12px 0;
-}
-
-.output-error-text {
-  color: #b91c1c;
-  font-size: 14px;
-  line-height: 1.5;
-}
-
-/*  Loading State  */
-.loading-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  padding: 40px 20px;
-  text-align: center;
-}
-
-.loading-icon-wrap {
-  font-size: 32px;
-  color: var(--accent);
-}
-
-.loading-icon-wrap.uploading {
-  animation: bounce-upload 1s ease-in-out infinite;
-}
-
-@keyframes bounce-upload {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-8px); }
-}
-
-.loading-title {
-  font-size: 17px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.loading-subtitle {
-  font-size: 13px;
-  color: var(--text-secondary);
-}
-
-.loading-dots {
-  display: flex;
-  gap: 6px;
-}
-
-.loading-dots span {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--accent);
-  animation: dot-pulse 1.2s ease-in-out infinite;
-}
-
-.loading-dots span:nth-child(2) { animation-delay: 0.2s; }
-.loading-dots span:nth-child(3) { animation-delay: 0.4s; }
-
-@keyframes dot-pulse {
-  0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
-  40% { opacity: 1; transform: scale(1); }
-}
-
-.loading-steps {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  width: 100%;
-  max-width: 280px;
-  text-align: left;
-}
-
-.loading-step {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 14px;
-  color: var(--text-secondary);
-}
-
-.loading-step.done {
-  color: #16a34a;
-  font-weight: 500;
-}
-
-.loading-step.active {
-  color: var(--text-primary);
-  font-weight: 500;
-}
-
-.step-icon {
-  font-size: 16px;
-  width: 20px;
-  text-align: center;
-  flex-shrink: 0;
-}
-
-.step-icon.spinning {
-  display: inline-block;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-.loading-warning {
-  font-size: 13px;
-  color: var(--text-secondary);
-  background: rgba(var(--accent-rgb, 99, 102, 241), 0.06);
-  border: 1px solid rgba(var(--accent-rgb, 99, 102, 241), 0.15);
-  border-radius: 8px;
-  padding: 12px 16px;
-  line-height: 1.6;
-  max-width: 300px;
-}
-
-.loading-warning strong {
-  color: var(--text-primary);
-}
-
 /* Insufficient Credits Error */
 .credits-error-card {
   display: flex;
@@ -796,39 +527,6 @@
 
 .credits-topup-link:hover {
   text-decoration: underline;
-}
-
-.output-actions {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-bottom: 16px;
-}
-
-.btn-export {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  border: 1.5px solid #e5e7eb;
-  border-radius: 8px;
-  background: #fff;
-  color: #374151;
-  font-size: 14px;
-  font-weight: 500;
-  font-family: inherit;
-  cursor: pointer;
-  transition: border-color 0.2s, color 0.2s, transform 0.15s;
-}
-
-.btn-export:hover {
-  border-color: #1a1a2e;
-  color: #1a1a2e;
-  transform: translateY(-1px);
-}
-
-.btn-export.copy {
-  min-width: 110px;
 }
 
 /* Action Buttons */
@@ -952,15 +650,13 @@
   }
 
   .input-actions,
-  .camera-actions-row,
-  .output-actions {
+  .camera-actions-row{
     flex-direction: column;
     align-items: stretch;
   }
 
   .btn-translate,
   .btn-clear,
-  .btn-export,
   .camera-action-btn,
   .file-browse-btn {
     justify-content: center;
@@ -1116,9 +812,6 @@
   transform: translateY(0);
 }
 
-.api-key-optional.disabled {
-  color: #9ca3af;
-}
 
 @media (max-width: 700px) {
   .translator-api-floating {

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -200,6 +200,90 @@
   margin-bottom: 20px;
 }
 
+/* Output Panel */
+.output-panel {
+  min-height: 450px;
+  display: flex;
+  flex-direction: column;
+}
+
+.output-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 60px 0;
+}
+
+.output-empty-icon {
+  font-size: 40px;
+  color: #d1d5db;
+}
+
+.output-empty-text {
+  font-size: 14px;
+  color: #9ca3af;
+  font-weight: 300;
+}
+
+.progress-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 16px;
+  padding: 28px 8px;
+}
+
+.progress-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.progress-card-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.progress-card-percent {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+.progress-track {
+  position: relative;
+  width: 100%;
+  height: 12px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #1a1a2e 0%, #3f3c68 100%);
+  transition: width 0.18s ease-out;
+}
+
+.progress-card-meta {
+  font-size: 14px;
+  font-weight: 500;
+  color: #4b5563;
+}
+
+.progress-card-hint {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #6b7280;
+}
+
 
 .input-card {
   background: #ffffff;
@@ -494,6 +578,191 @@
   color: #6b7280;
 }
 
+
+/*  Output Card  */
+.output-card {
+  background: #ffffff;
+  border: 1px solid #f3f4f6;
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06), 0 4px 12px rgba(0,0,0,0.04);
+  margin-bottom: 20px;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+}
+
+.output-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6b7280;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 20px;
+}
+
+.output-results {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 4px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.output-result-card {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.output-file-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a1a2e;
+  margin-bottom: 10px;
+  word-break: break-word;
+}
+
+.output-text {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: 'Poppins', sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #374151;
+}
+
+.output-error {
+  color: #b91c1c;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 12px 0;
+}
+
+.output-error-text {
+  color: #b91c1c;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/*  Loading State  */
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.loading-icon-wrap {
+  font-size: 32px;
+  color: var(--accent);
+}
+
+.loading-icon-wrap.uploading {
+  animation: bounce-upload 1s ease-in-out infinite;
+}
+
+@keyframes bounce-upload {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+
+.loading-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.loading-subtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.loading-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.loading-dots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: dot-pulse 1.2s ease-in-out infinite;
+}
+
+.loading-dots span:nth-child(2) { animation-delay: 0.2s; }
+.loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes dot-pulse {
+  0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+.loading-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 280px;
+  text-align: left;
+}
+
+.loading-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.loading-step.done {
+  color: #16a34a;
+  font-weight: 500;
+}
+
+.loading-step.active {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.step-icon {
+  font-size: 16px;
+  width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.step-icon.spinning {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.loading-warning {
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: rgba(var(--accent-rgb, 99, 102, 241), 0.06);
+  border: 1px solid rgba(var(--accent-rgb, 99, 102, 241), 0.15);
+  border-radius: 8px;
+  padding: 12px 16px;
+  line-height: 1.6;
+  max-width: 300px;
+}
+
+.loading-warning strong {
+  color: var(--text-primary);
+}
+
 /* Insufficient Credits Error */
 .credits-error-card {
   display: flex;
@@ -527,6 +796,39 @@
 
 .credits-topup-link:hover {
   text-decoration: underline;
+}
+
+.output-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.btn-export {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, transform 0.15s;
+}
+
+.btn-export:hover {
+  border-color: #1a1a2e;
+  color: #1a1a2e;
+  transform: translateY(-1px);
+}
+
+.btn-export.copy {
+  min-width: 110px;
 }
 
 /* Action Buttons */
@@ -650,13 +952,15 @@
   }
 
   .input-actions,
-  .camera-actions-row{
+  .camera-actions-row,
+  .output-actions {
     flex-direction: column;
     align-items: stretch;
   }
 
   .btn-translate,
   .btn-clear,
+  .btn-export,
   .camera-action-btn,
   .file-browse-btn {
     justify-content: center;
@@ -812,6 +1116,9 @@
   transform: translateY(0);
 }
 
+.api-key-optional.disabled {
+  color: #9ca3af;
+}
 
 @media (max-width: 700px) {
   .translator-api-floating {

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -793,7 +793,32 @@ const exportToDocx = async () => {
             </button>
           </div>
         )}
-        <div className="translator-panels">
+        {loadingPhase === 'uploading' && (
+          <div className="processing-banner">
+            <div className="processing-spinner" />
+            <span>Uploading your file... Please wait.</span>
+          </div>
+        )}
+
+        {loadingPhase === 'processing' && (
+          <div className="processing-banner">
+            <div className="processing-spinner" />
+            <span>
+              Processing your file with {engineDisplayName}... This may take a few moments.
+            </span>
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="processing-banner error">
+            {isInsufficientCreditsError(error) ? (
+              <CreditsErrorCard />
+            ) : (
+              <span>{error}</span>
+            )}
+          </div>
+        )}
+        <div className="translator-panels translator-panels-single">
 
           {/* Left Input Panel */}
           <div className="panel input-panel">
@@ -1056,57 +1081,6 @@ const exportToDocx = async () => {
               </button>
             </div>
           </div>
-
-          {/* Right Output Panel */}
-          <div className="panel output-panel">
-            <div className="panel-title">Translation Output</div>
-            {loadingPhase === 'uploading' ? (
-              <div className="loading-state">
-                <div className="loading-icon-wrap uploading">
-                  <FontAwesomeIcon icon={faUpload} />
-                </div>
-                <div className="loading-title">Uploading your files...</div>
-                <div className="loading-subtitle">Sending files to the server, please wait.</div>
-                <div className="loading-dots"><span /><span /><span /></div>
-              </div>
-            ) : loadingPhase === 'processing' ? (
-              <div className="loading-state">
-                <div className="loading-steps">
-                  <div className="loading-step done">
-                    <span className="step-icon">OK</span>
-                    <span>Upload complete</span>
-                  </div>
-                  {activeTab === 'file' && selectedFiles.some((f) => f.name.toLowerCase().endsWith('.zip')) && (
-                    <div className="loading-step active">
-                      <span className="step-icon spinning">...</span>
-                      <span>Extracting archive...</span>
-                    </div>
-                  )}
-                  <div className="loading-step active">
-                    <span className="step-icon spinning">...</span>
-                    <span>{isCalamariMode ? 'Calamari is recognising text...' : 'Gemini is recognising text...'}</span>
-                  </div>
-                </div>                <div className="loading-warning">
-                  This may take <strong>1-3 minutes per page</strong>.<br />
-                  Please do not close or refresh this tab.
-                </div>
-              </div>
-            ) : error ? (
-              isInsufficientCreditsError(error) ? (
-                <CreditsErrorCard />
-              ) : (
-                <div className="output-error">{error}</div>
-              )
-            ) : (
-              <div className="output-empty">
-                <div className="output-empty-icon">
-                  <FontAwesomeIcon icon={faFileLines} />
-                </div>
-                <div className="output-empty-text">Your translated text will appear here</div>
-              </div>
-            )}
-          </div>
-
         </div>
         </>
         )}


### PR DESCRIPTION
**Summary**
This PR cleans up both the Translator page code and CSS after moving the output to the new Results page.

**Changes**
Removed old output panel from TSX
Removed unused CSS (output + loading styles)
Fixed duplicate styles
Simplified layout to match new workflow

**Impact**
Cleaner and more readable code
Easier to maintain
No functional changes