### PR TITLE
Direct Text Input fixed

### DIFF
--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -17,6 +17,16 @@ OCR_SYSTEM_PROMPT = (
     "Do not add any commentary, explanation, or translation."
 )
 
+TEXT_SYSTEM_PROMPT = (
+    "You are an expert assistant for historical German newspaper text printed "
+    "or transcribed from Fraktur sources. The user will provide plain text, not "
+    "an image. Convert the input into readable modern German text while "
+    "preserving meaning, names, dates, spelling uncertainty and paragraph "
+    "structure as much as possible. Correct obvious OCR or transcription errors "
+    "only when the context supports the correction. Do not translate into "
+    "English. Return only the corrected text, with no commentary."
+)
+
 
 class GeminiOCRService:
     """
@@ -94,3 +104,48 @@ class GeminiOCRService:
             raise Exception(f"Model returned empty content (finish_reason: {finish_reason}).")
 
         return content.strip(), image_b64
+
+    def process_text(self, text: str) -> str:
+        """
+        Process direct text input without using image preprocessing or file
+        validation. This keeps the image/ZIP OCR pipeline independent.
+        """
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": TEXT_SYSTEM_PROMPT,
+                },
+                {
+                    "role": "user",
+                    "content": text,
+                },
+            ],
+        }
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        response = requests.post(self.url, headers=headers, json=payload, timeout=300)
+
+        if response.status_code != 200:
+            raise Exception(f"API request failed: {response.text}")
+
+        try:
+            response_json = response.json()
+        except ValueError:
+            raise Exception(f"Invalid JSON response: {response.text}")
+
+        if "choices" not in response_json:
+            raise Exception(f"Invalid API response: {response_json}")
+
+        choice = response_json["choices"][0]
+        content = choice["message"]["content"]
+        if content is None:
+            finish_reason = choice.get("finish_reason", "unknown")
+            raise Exception(f"Model returned empty content (finish_reason: {finish_reason}).")
+
+        return content.strip()

--- a/Backend/src/ocrApp/tests.py
+++ b/Backend/src/ocrApp/tests.py
@@ -158,6 +158,69 @@ class UploadApiTests(TestCase):
         self.assertIn("OpenRouter unavailable", data["page.jpg"]["error"])
 
 
+class TextInputApiTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = "/api/ocr/text/"
+
+    @patch("ocrApp.views.GeminiOCRService")
+    def test_text_input_returns_mocked_text_result(self, mock_service_class):
+        mock_service = mock_service_class.return_value
+        mock_service.process_text.return_value = "Modern German text"
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({"text": "Historischer Fraktur Text"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertIn("text-input.txt", data)
+        self.assertEqual(data["text-input.txt"]["text"], "Modern German text")
+        mock_service_class.assert_called_once_with(api_key=None)
+        mock_service.process_text.assert_called_once_with("Historischer Fraktur Text")
+
+    def test_text_input_without_text_returns_400(self):
+        response = self.client.post(
+            self.url,
+            data=json.dumps({"text": "   "}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "No text provided.")
+
+    def test_text_input_invalid_user_api_key_returns_400(self):
+        response = self.client.post(
+            self.url,
+            data=json.dumps({"text": "Historischer Fraktur Text"}),
+            content_type="application/json",
+            HTTP_X_USER_API_KEY="invalid-key",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("invalid format", response.json()["error"])
+
+    @patch("ocrApp.views.GeminiOCRService")
+    def test_text_service_failure_returns_per_input_error(self, mock_service_class):
+        mock_service = mock_service_class.return_value
+        mock_service.process_text.side_effect = RuntimeError("OpenRouter unavailable")
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({"text": "Historischer Fraktur Text"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertIn("text-input.txt", data)
+        self.assertIn("OpenRouter unavailable", data["text-input.txt"]["error"])
+
+
 class CreditsApiTests(TestCase):
     def setUp(self):
         self.client = Client()

--- a/Backend/src/ocrApp/urls.py
+++ b/Backend/src/ocrApp/urls.py
@@ -8,6 +8,9 @@ urlpatterns = [
     # Upload image and run OCR
     path("upload/", views.ImageUploadAndRecogniseView.as_view(), name="upload"),
 
+    # Process direct text input without image upload validation
+    path("text/", views.TextRecogniseView.as_view(), name="text"),
+
     # Remaining OpenRouter credits
     path("credits/", views.CreditsView.as_view(), name="credits"),
 

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 # We validate the format so only well-formed keys are forwarded.
 _API_KEY_RE = re.compile(r'^sk-or-v1-[A-Za-z0-9]{1,200}$')
 _API_KEY_MAX_LEN = 220  # hard upper bound to prevent oversized header abuse
+_TEXT_INPUT_MAX_CHARS = 20000
 
 
 def _validate_user_api_key(raw: str | None) -> tuple[str | None, str | None]:
@@ -140,6 +141,51 @@ class ContactMessageView(View):
                 "created_at": contact_message.created_at.isoformat(),
             },
             status=201,
+        )
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class TextRecogniseView(View):
+    """
+    POST /api/ocr/text/
+    Process direct text input without routing it through image upload validation.
+    """
+
+    def post(self, request):
+        try:
+            payload = json.loads(request.body.decode("utf-8") or "{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"error": "Invalid JSON body."}, status=400)
+
+        text = str(payload.get("text", "")).strip()
+        if not text:
+            return JsonResponse({"error": "No text provided."}, status=400)
+
+        if len(text) > _TEXT_INPUT_MAX_CHARS:
+            return JsonResponse(
+                {"error": f"Text input exceeds {_TEXT_INPUT_MAX_CHARS} characters."},
+                status=400,
+            )
+
+        raw_key = request.headers.get("X-User-Api-Key") or None
+        user_api_key, key_error = _validate_user_api_key(raw_key)
+        if key_error:
+            return JsonResponse({"error": key_error}, status=400)
+
+        service = GeminiOCRService(api_key=user_api_key)
+
+        try:
+            processed_text = service.process_text(text)
+        except Exception as exc:
+            logger.exception("Failed to process direct text input.")
+            return JsonResponse(
+                {"text-input.txt": {"error": str(exc)}},
+                status=200,
+            )
+
+        return JsonResponse(
+            {"text-input.txt": {"text": processed_text}},
+            status=200,
         )
 
 

--- a/OCR-FRONTEND/src/api.tsx
+++ b/OCR-FRONTEND/src/api.tsx
@@ -104,17 +104,52 @@ export function handleTranslate(params: {
 }): Promise<TranslateResponse> {
   const { type, data, apiKey, engine = 'gemini', onUploadDone } = params;
 
+  // TEXT INPUT
+  if (type === 'text') {
+    if (typeof data !== 'string') {
+      return Promise.reject(new Error(`Invalid input: type='${type}' does not match data`));
+    }
+
+    const text = data.trim();
+    if (!text) {
+      return Promise.reject(new Error('No text provided.'));
+    }
+
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    };
+    if (apiKey?.trim()) {
+      headers['X-User-Api-Key'] = apiKey.trim();
+    }
+
+    onUploadDone?.();
+
+    return fetch(`${API_BASE_URL}/text/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ text, engine }),
+    }).then(async (response) => {
+      let responseBody: unknown = null;
+      try {
+        responseBody = await response.json();
+      } catch {
+        responseBody = null;
+      }
+
+      if (!response.ok) {
+        const body = responseBody as { error?: string } | null;
+        throw new Error(body?.error || `HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return responseBody as TranslateResponse;
+    });
+  }
+
   const formData = new FormData();
   formData.append('engine', engine);
 
-  // TEXT INPUT
-  if (type === 'text' && typeof data === 'string') {
-    const file = new File([data], 'text-input.txt', { type: 'text/plain' });
-    formData.append('images', file);
-  }
-
   // FILE INPUT (single OR multiple)
-  else if (type === 'file') {
+  if (type === 'file') {
     const files = (Array.isArray(data) ? data : [data]) as File[];
 
     const allowedTypes = [

--- a/OCR-FRONTEND/src/css/TranslatorPage.css
+++ b/OCR-FRONTEND/src/css/TranslatorPage.css
@@ -349,6 +349,37 @@
   letter-spacing: 0.04em;
 }
 
+.text-input-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.text-input-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #6b7280;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: normal;
+}
+
+.text-input-note-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .fraktur-textarea {
   width: 100%;
   min-height: 200px;

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -841,7 +841,13 @@ const exportToDocx = async () => {
             {/* Text Tab */}
             {activeTab === 'text' && (
               <>
-                <div className="input-label">Enter Fraktur Text</div>
+                <div className="input-label text-input-label">
+                  <span>Enter Fraktur Text</span>
+                  <span className="text-input-note" role="note">
+                    <span className="text-input-note-icon" aria-hidden="true">!</span>
+                    Calamari only works with image data and cannot recognise typed text. Text input is processed with the Gemini API only.
+                  </span>
+                </div>
                 <textarea
                   className="fraktur-textarea"
                   placeholder="Paste or type your Fraktur text here..."


### PR DESCRIPTION
## Summary

This PR implements support for translating direct text input and improves the Translator page messaging around OCR engine limitations.

## Changes

- Added text-only translation support so typed Fraktur text is processed through the backend text endpoint instead of being uploaded as a `text/plain` file.
- Kept the existing image and ZIP OCR upload workflow unchanged.
- Added backend text-processing logic for direct text input using the Gemini API.
- Added backend mock tests for the text translation endpoint, including success, empty input, invalid API key, and service failure cases.
- Updated the Text input UI to inform users that Calamari only works with image data and that direct text input is processed with the Gemini API only.

## Testing

- Added backend unit tests for the text-only translation workflow.
- Existing image/ZIP OCR upload handling remains separate from the new text flow.
