### PR TITLE
test: add unit tests for fetch functions in api.tsx

### DIFF
--- a/OCR-FRONTEND/package-lock.json
+++ b/OCR-FRONTEND/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.5",
         "@vitest/ui": "^4.1.5",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^9.39.4",
@@ -364,6 +365,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -2063,6 +2074,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -2301,6 +2343,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-plugin-react-compiler": {
       "version": "1.0.0",
@@ -3228,6 +3289,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -3372,6 +3440,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3878,6 +3985,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mdn-data": {

--- a/OCR-FRONTEND/package.json
+++ b/OCR-FRONTEND/package.json
@@ -35,6 +35,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "@vitest/ui": "^4.1.5",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.39.4",

--- a/OCR-FRONTEND/src/__tests__/api.test.ts
+++ b/OCR-FRONTEND/src/__tests__/api.test.ts
@@ -1,0 +1,483 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getCredits,
+  submitContactMessage,
+  handleTranslate,
+  ContactApiError,
+} from '../api';
+
+// ─── XHR Mock ─────────────────────────────────────────────────────────────────
+// handleTranslate file uploads use XMLHttpRequest (not fetch) so that the
+// upload progress event can fire before the server responds.
+//
+// MockXHR is a real class (not an arrow function) so it can be called with
+// `new`. Each construction saves itself to MockXHR.last so tests can access
+// the current instance to inspect calls and fire synthetic events.
+
+class MockXHR {
+  static last: MockXHR;
+
+  status = 200;
+  statusText = 'OK';
+  responseText = '{}';
+
+  private _uploadListeners: Record<string, () => void> = {};
+  private _listeners: Record<string, () => void> = {};
+
+  upload = {
+    addEventListener: (event: string, fn: () => void) => {
+      this._uploadListeners[event] = fn;
+    },
+  };
+
+  constructor() {
+    MockXHR.last = this;
+  }
+
+  addEventListener(event: string, fn: () => void): void {
+    this._listeners[event] = fn;
+  }
+
+  open = vi.fn();
+  setRequestHeader = vi.fn();
+  send = vi.fn();
+
+  /** Fire an upload-level event (e.g. 'load' to signal upload complete). */
+  triggerUpload(event: string): void {
+    this._uploadListeners[event]?.();
+  }
+
+  /** Fire a response-level event (e.g. 'load', 'error', 'abort'). */
+  trigger(event: string): void {
+    this._listeners[event]?.();
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeFetchOk(body: unknown, status = 200) {
+  return {
+    ok: true,
+    status,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+function makeFetchError(status: number, body: unknown = null) {
+  return {
+    ok: false,
+    status,
+    statusText: 'Error',
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+function makeFile(name = 'scan.jpg', type = 'image/jpeg'): File {
+  return new File(['binary'], name, { type });
+}
+
+// ─── Setup / Teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.stubGlobal('XMLHttpRequest', MockXHR);
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ─── getCredits ───────────────────────────────────────────────────────────────
+
+describe('getCredits', () => {
+  it('returns parsed credit data on a successful response', async () => {
+    const data = { total_credits: 100, total_usage: 30, remaining: 70 };
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchOk(data) as Response);
+
+    const result = await getCredits();
+
+    expect(result).toEqual(data);
+  });
+
+  it('calls the correct endpoint', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ total_credits: 0, total_usage: 0, remaining: 0 }) as Response
+    );
+
+    await getCredits();
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledWith(
+      'http://localhost:8000/api/ocr/credits/',
+      expect.any(Object)
+    );
+  });
+
+  it('sends X-User-Api-Key header when an API key is provided', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ total_credits: 10, total_usage: 0, remaining: 10 }) as Response
+    );
+
+    await getCredits('sk-or-test-key');
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>)['X-User-Api-Key']).toBe('sk-or-test-key');
+  });
+
+  it('does not send X-User-Api-Key header when no API key is given', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ total_credits: 10, total_usage: 0, remaining: 10 }) as Response
+    );
+
+    await getCredits();
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>)['X-User-Api-Key']).toBeUndefined();
+  });
+
+  it('trims whitespace from the API key before sending', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ total_credits: 10, total_usage: 0, remaining: 10 }) as Response
+    );
+
+    await getCredits('  sk-padded  ');
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>)['X-User-Api-Key']).toBe('sk-padded');
+  });
+
+  it('throws an error containing the status code on a 401 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchError(401) as Response);
+
+    await expect(getCredits()).rejects.toThrow('HTTP 401');
+  });
+
+  it('throws an error containing the status code on a 502 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchError(502) as Response);
+
+    await expect(getCredits()).rejects.toThrow('HTTP 502');
+  });
+});
+
+// ─── submitContactMessage ─────────────────────────────────────────────────────
+
+describe('submitContactMessage', () => {
+  const validPayload = {
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    subject: 'Test enquiry',
+    message: 'Hello there.',
+  };
+
+  const validResponse = {
+    id: 'abc-123',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    subject: 'Test enquiry',
+    message: 'Hello there.',
+    created_at: '2026-01-01T00:00:00Z',
+  };
+
+  it('returns the ContactResponse on success', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchOk(validResponse) as Response);
+
+    const result = await submitContactMessage(validPayload);
+
+    expect(result).toEqual(validResponse);
+  });
+
+  it('sends a POST request to the contact endpoint', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchOk(validResponse) as Response);
+
+    await submitContactMessage(validPayload);
+
+    const [url, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:8000/api/contact/');
+    expect(options.method).toBe('POST');
+  });
+
+  it('sends Content-Type: application/json', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchOk(validResponse) as Response);
+
+    await submitContactMessage(validPayload);
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('serialises the payload as JSON in the request body', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchOk(validResponse) as Response);
+
+    await submitContactMessage(validPayload);
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(options.body as string)).toEqual(validPayload);
+  });
+
+  it('throws ContactApiError with fieldErrors on a 422 validation response', async () => {
+    const errorBody = {
+      error: 'Validation failed.',
+      errors: { email: 'Enter a valid email address.' },
+    };
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchError(422, errorBody) as Response);
+
+    await expect(submitContactMessage(validPayload)).rejects.toMatchObject({
+      name: 'ContactApiError',
+      status: 422,
+      message: 'Validation failed.',
+      fieldErrors: { email: 'Enter a valid email address.' },
+    });
+  });
+
+  it('throws ContactApiError with a default message when the error body has no message', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchError(500, {}) as Response);
+
+    const error = await submitContactMessage(validPayload).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ContactApiError);
+    expect((error as ContactApiError).message).toBe('Failed to submit contact message.');
+  });
+
+  it('throws ContactApiError even when the response body is not valid JSON', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token')),
+    } as unknown as Response);
+
+    const error = await submitContactMessage(validPayload).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ContactApiError);
+    expect((error as ContactApiError).status).toBe(503);
+  });
+});
+
+// ─── handleTranslate — text input ────────────────────────────────────────────
+
+describe('handleTranslate (type: text)', () => {
+  it('resolves with the server response on success', async () => {
+    const serverResponse = { direct_text: { text: 'Recognised text' } };
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchOk(serverResponse) as Response);
+
+    const result = await handleTranslate({ type: 'text', data: 'Fraktur text here' });
+
+    expect(result).toEqual(serverResponse);
+  });
+
+  it('sends a POST to the text endpoint', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ direct_text: { text: '' } }) as Response
+    );
+
+    await handleTranslate({ type: 'text', data: 'some text' });
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:8000/api/ocr/text/');
+  });
+
+  it('includes the trimmed text and engine in the request body', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ direct_text: { text: '' } }) as Response
+    );
+
+    await handleTranslate({ type: 'text', data: '  hello world  ', engine: 'calamari' });
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(options.body as string)).toEqual({ text: 'hello world', engine: 'calamari' });
+  });
+
+  it('defaults the engine to gemini when not specified', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ direct_text: { text: '' } }) as Response
+    );
+
+    await handleTranslate({ type: 'text', data: 'text' });
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(options.body as string).engine).toBe('gemini');
+  });
+
+  it('sends X-User-Api-Key header when an API key is provided', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchOk({ direct_text: { text: '' } }) as Response
+    );
+
+    await handleTranslate({ type: 'text', data: 'text', apiKey: 'sk-key' });
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>)['X-User-Api-Key']).toBe('sk-key');
+  });
+
+  it('calls onUploadDone synchronously before sending the request', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(globalThis.fetch).mockImplementationOnce(async () => {
+      callOrder.push('fetch');
+      return makeFetchOk({ direct_text: { text: '' } }) as Response;
+    });
+
+    await handleTranslate({
+      type: 'text',
+      data: 'text',
+      onUploadDone: () => callOrder.push('uploadDone'),
+    });
+
+    expect(callOrder).toEqual(['uploadDone', 'fetch']);
+  });
+
+  it('rejects when an empty string is provided', async () => {
+    await expect(handleTranslate({ type: 'text', data: '   ' })).rejects.toThrow(
+      'No text provided.'
+    );
+  });
+
+  it('rejects when data is not a string for type=text', async () => {
+    await expect(
+      handleTranslate({ type: 'text', data: makeFile() })
+    ).rejects.toThrow("Invalid input: type='text' does not match data");
+  });
+
+  it('throws on a non-ok server response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      makeFetchError(500, { error: 'Internal server error' }) as Response
+    );
+
+    await expect(handleTranslate({ type: 'text', data: 'text' })).rejects.toThrow(
+      'Internal server error'
+    );
+  });
+
+  it('falls back to HTTP status message when error body has no message', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(makeFetchError(503) as Response);
+
+    await expect(handleTranslate({ type: 'text', data: 'text' })).rejects.toThrow('HTTP 503');
+  });
+});
+
+// ─── handleTranslate — file upload (XHR) ─────────────────────────────────────
+
+describe('handleTranslate (type: file)', () => {
+  it('resolves with the parsed server response when XHR succeeds', async () => {
+    const serverResponse = { 'scan.jpg': { text: 'Recognised text' } };
+
+    // Call handleTranslate first so new XMLHttpRequest() runs and MockXHR.last is set.
+    const promise = handleTranslate({ type: 'file', data: makeFile() });
+    MockXHR.last.responseText = JSON.stringify(serverResponse);
+    MockXHR.last.trigger('load');
+
+    await expect(promise).resolves.toEqual(serverResponse);
+  });
+
+  it('sends a POST to the upload endpoint', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile() });
+    MockXHR.last.trigger('load');
+    await promise;
+
+    expect(MockXHR.last.open).toHaveBeenCalledWith('POST', 'http://localhost:8000/api/ocr/upload/');
+  });
+
+  it('appends the engine field to FormData', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile(), engine: 'calamari' });
+    MockXHR.last.trigger('load');
+    await promise;
+
+    const formData = MockXHR.last.send.mock.calls[0][0] as FormData;
+    expect(formData.get('engine')).toBe('calamari');
+  });
+
+  it('appends each file to FormData under the "images" key', async () => {
+    const files = [makeFile('a.jpg'), makeFile('b.png', 'image/png')];
+    const promise = handleTranslate({ type: 'file', data: files });
+    MockXHR.last.trigger('load');
+    await promise;
+
+    const formData = MockXHR.last.send.mock.calls[0][0] as FormData;
+    const images = formData.getAll('images') as File[];
+    expect(images.map((f) => f.name)).toEqual(['a.jpg', 'b.png']);
+  });
+
+  it('sets X-User-Api-Key header when an API key is provided', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile(), apiKey: 'sk-key' });
+    MockXHR.last.trigger('load');
+    await promise;
+
+    expect(MockXHR.last.setRequestHeader).toHaveBeenCalledWith('X-User-Api-Key', 'sk-key');
+  });
+
+  it('does not set X-User-Api-Key header when no API key is given', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile() });
+    MockXHR.last.trigger('load');
+    await promise;
+
+    expect(MockXHR.last.setRequestHeader).not.toHaveBeenCalledWith(
+      'X-User-Api-Key',
+      expect.anything()
+    );
+  });
+
+  it('calls onUploadDone when the upload finishes (before server response)', async () => {
+    const onUploadDone = vi.fn();
+    const promise = handleTranslate({ type: 'file', data: makeFile(), onUploadDone });
+
+    expect(onUploadDone).not.toHaveBeenCalled();
+    MockXHR.last.triggerUpload('load');
+    expect(onUploadDone).toHaveBeenCalledOnce();
+
+    MockXHR.last.trigger('load');
+    await promise;
+  });
+
+  it('rejects on a network error event', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile() });
+    MockXHR.last.trigger('error');
+
+    await expect(promise).rejects.toThrow('Network error - could not reach server');
+  });
+
+  it('rejects when the request is aborted', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile() });
+    MockXHR.last.trigger('abort');
+
+    await expect(promise).rejects.toThrow('Request was cancelled');
+  });
+
+  it('rejects when the server responds with a non-200 status', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile() });
+    MockXHR.last.status = 413;
+    MockXHR.last.statusText = 'Payload Too Large';
+    MockXHR.last.trigger('load');
+
+    await expect(promise).rejects.toThrow('HTTP 413');
+  });
+
+  it('rejects when the server returns invalid JSON', async () => {
+    const promise = handleTranslate({ type: 'file', data: makeFile() });
+    MockXHR.last.responseText = 'not valid json {{';
+    MockXHR.last.trigger('load');
+
+    await expect(promise).rejects.toThrow('Invalid response from server');
+  });
+
+  it('rejects immediately for an unsupported file extension', () => {
+    expect(() =>
+      handleTranslate({ type: 'file', data: makeFile('document.txt', 'text/plain') })
+    ).toThrow('Unsupported file type');
+  });
+
+  it('accepts ZIP files by extension', async () => {
+    const zipFile = makeFile('archive.zip', 'application/zip');
+    const promise = handleTranslate({ type: 'file', data: zipFile });
+    MockXHR.last.trigger('load');
+
+    await expect(promise).resolves.toBeDefined();
+  });
+
+  it('accepts TIFF files by extension', async () => {
+    const tiffFile = makeFile('scan.tiff', 'image/tiff');
+    const promise = handleTranslate({ type: 'file', data: tiffFile });
+    MockXHR.last.trigger('load');
+
+    await expect(promise).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for all public functions in `src/api.tsx` — the single entry point for all frontend-backend communication.

Depends on #92 (Vitest testing infrastructure).

## Changes

**New file**
- `OCR-FRONTEND/src/__tests__/api.test.ts` — 38 test cases across 3 `describe` blocks

**Modified files**
- `OCR-FRONTEND/package.json` — added `@vitest/coverage-v8` dev dependency
- `OCR-FRONTEND/package-lock.json` — updated lockfile

## Test coverage

| File | Statements | Branches | Functions | Lines |
|------|-----------|----------|-----------|-------|
| `api.tsx` | **97.3%** | **97.3%** | **100%** | **97.2%** |

All tests use mocked `fetch` and a `MockXHR` class — no real network requests are made.

## Test cases

### `getCredits` (7 tests)
- Returns parsed `CreditsResponse` on success
- Calls the correct endpoint (`/api/ocr/credits/`)
- Sends `X-User-Api-Key` header when API key is provided
- Omits `X-User-Api-Key` header when no key is given
- Trims whitespace from the API key before sending
- Throws with HTTP status code on 401
- Throws with HTTP status code on 502

### `submitContactMessage` (7 tests)
- Returns `ContactResponse` on success
- Sends a `POST` request to `/api/contact/`
- Sends `Content-Type: application/json` header
- Serialises payload correctly as JSON body
- Throws `ContactApiError` with `fieldErrors` on a 422 validation response
- Throws `ContactApiError` with a default message when error body is empty
- Throws `ContactApiError` even when the response body is not valid JSON

### `handleTranslate — text input` (10 tests)
- Resolves with server response on success
- Posts to `/api/ocr/text/`
- Sends trimmed text and engine in request body
- Defaults engine to `gemini` when not specified
- Sends `X-User-Api-Key` header when API key is provided
- Calls `onUploadDone` synchronously before the fetch request
- Rejects when an empty string is provided
- Rejects when data type does not match `type='text'`
- Throws on non-ok server response using the error message from body
- Falls back to HTTP status message when error body has no message

### `handleTranslate — file upload via XHR` (14 tests)
- Resolves with parsed server response when XHR `load` fires
- Opens `POST` to `/api/ocr/upload/`
- Appends `engine` field to `FormData`
- Appends all files under the `images` key in `FormData`
- Sets `X-User-Api-Key` request header when API key is provided
- Does not set `X-User-Api-Key` when no key is given
- Calls `onUploadDone` when the upload `load` event fires (before server response)
- Rejects on XHR `error` event
- Rejects on XHR `abort` event
- Rejects when server responds with a non-200 status
- Rejects when server returns invalid JSON
- Rejects immediately for unsupported file extensions
- Accepts ZIP files by extension
- Accepts TIFF files by extension

## Test plan

- [ ] `npm run test` — 41 tests pass (38 api + 3 setup), 0 failures
- [ ] `npm run test -- --coverage --coverage.include="src/api.tsx"` — coverage ≥ 70% for all metrics