### PR TITLE
test: expand frontend test coverage to 84% across all components

### DIFF
--- a/OCR-FRONTEND/src/__tests__/Navbar.test.tsx
+++ b/OCR-FRONTEND/src/__tests__/Navbar.test.tsx
@@ -78,4 +78,33 @@ describe('Navbar', () => {
     const el = screen.getByText(ctaLink.label).closest('a');
     expect(el?.className).toContain('cta');
   });
+
+  it('passes the api key from localStorage to getCredits', async () => {
+    localStorage.setItem('openrouter_api_key', 'sk-my-key');
+    vi.mocked(api.getCredits).mockResolvedValue({ remaining: 2.0 });
+    renderNavbar();
+    await waitFor(() => {
+      expect(api.getCredits).toHaveBeenCalledWith('sk-my-key');
+    });
+  });
+
+  it('re-fetches credits when apikey-changed event fires', async () => {
+    vi.mocked(api.getCredits)
+      .mockResolvedValueOnce({ remaining: 1.0 })
+      .mockResolvedValueOnce({ remaining: 3.0 });
+    renderNavbar();
+    await waitFor(() => expect(screen.getByText('$1.00')).toBeInTheDocument());
+    window.dispatchEvent(new Event('apikey-changed'));
+    await waitFor(() => expect(screen.getByText('$3.00')).toBeInTheDocument());
+  });
+
+  it('re-fetches credits when credits-refresh event fires', async () => {
+    vi.mocked(api.getCredits)
+      .mockResolvedValueOnce({ remaining: 5.0 })
+      .mockResolvedValueOnce({ remaining: 4.0 });
+    renderNavbar();
+    await waitFor(() => expect(screen.getByText('$5.00')).toBeInTheDocument());
+    window.dispatchEvent(new Event('credits-refresh'));
+    await waitFor(() => expect(screen.getByText('$4.00')).toBeInTheDocument());
+  });
 });

--- a/OCR-FRONTEND/src/__tests__/ResultView.test.tsx
+++ b/OCR-FRONTEND/src/__tests__/ResultView.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ResultView, { type ResultItem } from '../components/ResultView';
 
 const mockItem = (overrides?: Partial<ResultItem>): ResultItem => ({
@@ -126,5 +126,177 @@ describe('ResultView', () => {
     render(<ResultView items={items} previews={mockPreviews} />);
     const errorDot = screen.getByLabelText('error');
     expect(errorDot).toBeInTheDocument();
+  });
+});
+
+// ── Calamari warning ──────────────────────────────────────────────────────────
+
+describe('ResultView — Calamari quality warning', () => {
+  it('shows a quality warning when the result engine is calamari', () => {
+    render(<ResultView items={[mockItem({ engine: 'calamari' })]} previews={{}} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Calamari recognition quality may be poor/i)).toBeInTheDocument();
+  });
+
+  it('does not show a quality warning for gemini engine', () => {
+    render(<ResultView items={[mockItem({ engine: 'gemini' })]} previews={{}} />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('does not show a quality warning when engine is unspecified', () => {
+    render(<ResultView items={[mockItem()]} previews={{}} />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+// ── Zoom and pan ──────────────────────────────────────────────────────────────
+
+describe('ResultView — zoom and pan', () => {
+  const previewMap: Record<string, string> = {
+    'test.jpg': 'data:image/jpeg;base64,abc123',
+  };
+
+  beforeEach(() => {
+    // setPointerCapture / releasePointerCapture may not exist in this jsdom version
+    Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'releasePointerCapture', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
+  });
+
+  const getViewport = (container: HTMLElement) =>
+    container.querySelector('.result-source-viewport') as HTMLElement;
+
+  const getImg = (container: HTMLElement) =>
+    container.querySelector('img') as HTMLElement;
+
+  it('renders the zoom viewport when a preview URL is provided', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    expect(getViewport(container)).toBeInTheDocument();
+  });
+
+  it('zooms in on wheel scroll up (deltaY < 0)', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    fireEvent.wheel(getViewport(container), { deltaY: -100 });
+    expect(getImg(container).style.transform).toContain('scale(1.15)');
+  });
+
+  it('clamps zoom at maxZoom (4) after repeated zoom-in scrolls', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    for (let i = 0; i < 25; i++) {
+      fireEvent.wheel(getViewport(container), { deltaY: -100 });
+    }
+    expect(getImg(container).style.transform).toContain('scale(4)');
+  });
+
+  it('zooms out on wheel scroll down and resets pan at min zoom', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    fireEvent.wheel(viewport, { deltaY: 100 });
+    expect(getImg(container).style.transform).toBe('translate(0px, 0px) scale(1)');
+  });
+
+  it('does not start panning when zoom is at minimum', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.pointerDown(viewport, { clientX: 100, clientY: 100, pointerId: 1 });
+    expect(viewport).not.toHaveClass('panning');
+  });
+
+  it('adds panning class on pointer down when zoomed in', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    fireEvent.pointerDown(viewport, { clientX: 0, clientY: 0, pointerId: 1 });
+    expect(viewport).toHaveClass('panning');
+  });
+
+  it('updates pan position on pointer move while panning', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100, clientX: 0, clientY: 0 });
+    fireEvent.pointerDown(viewport, { clientX: 0, clientY: 0, pointerId: 1 });
+    fireEvent.pointerMove(viewport, { clientX: 20, clientY: 30, pointerId: 1 });
+    expect(getImg(container).style.transform).toContain('translate(20px, 30px)');
+  });
+
+  it('pointer move does nothing when not panning', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    fireEvent.pointerMove(viewport, { clientX: 20, clientY: 30, pointerId: 1 });
+    expect(getImg(container).style.transform).toContain('translate(0px, 0px)');
+  });
+
+  it('ends panning on pointer up', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    fireEvent.pointerDown(viewport, { clientX: 0, clientY: 0, pointerId: 1 });
+    expect(viewport).toHaveClass('panning');
+    fireEvent.pointerUp(viewport, { pointerId: 1 });
+    expect(viewport).not.toHaveClass('panning');
+  });
+
+  it('ends panning on pointer leave', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    fireEvent.pointerDown(viewport, { clientX: 0, clientY: 0, pointerId: 1 });
+    fireEvent.pointerLeave(viewport, { pointerId: 1 });
+    expect(viewport).not.toHaveClass('panning');
+  });
+
+  it('ends panning on pointer cancel', () => {
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    fireEvent.pointerDown(viewport, { clientX: 0, clientY: 0, pointerId: 1 });
+    fireEvent.pointerCancel(viewport, { pointerId: 1 });
+    expect(viewport).not.toHaveClass('panning');
+  });
+
+  it('releases pointer capture in endPan when hasPointerCapture returns true', () => {
+    Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue(true),
+    });
+    const { container } = render(<ResultView items={[mockItem()]} previews={previewMap} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    fireEvent.pointerDown(viewport, { clientX: 0, clientY: 0, pointerId: 1 });
+    fireEvent.pointerUp(viewport, { pointerId: 1 });
+    expect(HTMLElement.prototype.releasePointerCapture).toHaveBeenCalled();
+  });
+
+  it('resets zoom and pan when switching to a different item', async () => {
+    const user = userEvent.setup();
+    const items = [
+      mockItem({ fileName: 'file1.jpg', text: 'Text 1' }),
+      mockItem({ fileName: 'file2.jpg', text: 'Text 2' }),
+    ];
+    const previews = {
+      'file1.jpg': 'data:image/jpeg;base64,aaa',
+      'file2.jpg': 'data:image/jpeg;base64,bbb',
+    };
+    const { container } = render(<ResultView items={items} previews={previews} />);
+    const viewport = getViewport(container);
+    fireEvent.wheel(viewport, { deltaY: -100 });
+    expect(getImg(container).style.transform).toContain('scale(1.15)');
+    await user.click(screen.getByTitle('file2.jpg'));
+    expect(getImg(container).style.transform).toBe('translate(0px, 0px) scale(1)');
   });
 });

--- a/OCR-FRONTEND/src/__tests__/Translatorpage.test.tsx
+++ b/OCR-FRONTEND/src/__tests__/Translatorpage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -12,15 +12,57 @@ vi.mock('../api', () => ({
 }));
 
 vi.mock('../components/ResultsSection', () => ({
-  default: ({ onBack }: { onBack: () => void }) => (
+  default: ({
+    onBack,
+    onCopy,
+    onExportPdf,
+    onExportDocx,
+    onClear,
+  }: {
+    onBack: () => void;
+    onCopy: () => void;
+    onExportPdf: () => void;
+    onExportDocx: () => void;
+    onClear: () => void;
+  }) => (
     <div data-testid="results-section">
       <button onClick={onBack}>Back</button>
+      <button onClick={onCopy}>Copy Text</button>
+      <button onClick={onExportPdf}>Export PDF</button>
+      <button onClick={onExportDocx}>Export DOCX</button>
+      <button onClick={onClear}>New Translation</button>
     </div>
   ),
 }));
 
 vi.mock('../utils/extractPreviews', () => ({
   extractPreviews: vi.fn(() => ({})),
+}));
+
+vi.mock('jspdf', () => ({
+  // Must use a regular function (not arrow) so it works with `new jsPDF()`
+  jsPDF: vi.fn(function (this: Record<string, unknown>) {
+    this.internal = { pageSize: { getWidth: () => 210, getHeight: () => 297 } };
+    this.setFont = vi.fn();
+    this.setFontSize = vi.fn();
+    this.splitTextToSize = vi.fn().mockReturnValue(['mocked line']);
+    this.text = vi.fn();
+    this.addPage = vi.fn();
+    this.line = vi.fn();
+    this.save = vi.fn();
+  }),
+}));
+
+vi.mock('file-saver', () => ({
+  saveAs: vi.fn(),
+}));
+
+vi.mock('docx', () => ({
+  Document: vi.fn(function () {}),
+  Packer: { toBlob: vi.fn().mockResolvedValue(new Blob(['docx'])) },
+  Paragraph: vi.fn(function () {}),
+  TextRun: vi.fn(function () {}),
+  HeadingLevel: { HEADING_1: 'Heading1' },
 }));
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -286,5 +328,441 @@ describe('TranslatorPage', () => {
 
     await user.click(screen.getByRole('button', { name: /Back/i }));
     expect(screen.getByText('Fraktur Text Recogniser')).toBeInTheDocument();
+  });
+
+  // ── View Results Banner ────────────────────────────────────────────────────
+
+  it('shows view-results banner after returning to input from results', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.handleTranslate).mockResolvedValueOnce({
+      direct_text: { text: 'Recognised text' },
+    });
+    renderPage();
+    await user.type(
+      screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
+      'Some text'
+    );
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+    await waitFor(() => expect(screen.getByTestId('results-section')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Back/i }));
+    expect(screen.getByText(/View results/i)).toBeInTheDocument();
+  });
+
+  it('navigates back to results when View results banner button is clicked', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.handleTranslate).mockResolvedValueOnce({
+      direct_text: { text: 'Recognised text' },
+    });
+    renderPage();
+    await user.type(
+      screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
+      'Some text'
+    );
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+    await waitFor(() => expect(screen.getByTestId('results-section')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Back/i }));
+    await user.click(screen.getByText(/View results →/i));
+    expect(screen.getByTestId('results-section')).toBeInTheDocument();
+  });
+
+  // ── Credits error ──────────────────────────────────────────────────────────
+
+  it('shows CreditsErrorCard when translation error contains "insufficient"', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.handleTranslate).mockRejectedValueOnce(
+      new Error('insufficient credits')
+    );
+    renderPage();
+    await user.type(
+      screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
+      'Some text'
+    );
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Insufficient Balance')).toBeInTheDocument();
+    });
+  });
+
+  // ── Copy / Export ──────────────────────────────────────────────────────────
+
+  it('calls navigator.clipboard.writeText when Copy Text is clicked', async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+      writable: true,
+    });
+    vi.mocked(api.handleTranslate).mockResolvedValueOnce({
+      direct_text: { text: 'Recognised text' },
+    });
+    renderPage();
+    await user.type(
+      screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
+      'Some text'
+    );
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+    await waitFor(() => expect(screen.getByTestId('results-section')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Copy Text/i }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+  });
+
+  it('calls jsPDF.save on Export PDF click', async () => {
+    const user = userEvent.setup();
+    const { jsPDF } = await import('jspdf');
+    const mockSave = vi.fn();
+    vi.mocked(jsPDF).mockImplementation(function (this: Record<string, unknown>) {
+      this.internal = { pageSize: { getWidth: () => 210, getHeight: () => 297 } };
+      this.setFont = vi.fn();
+      this.setFontSize = vi.fn();
+      this.splitTextToSize = vi.fn().mockReturnValue(['line']);
+      this.text = vi.fn();
+      this.addPage = vi.fn();
+      this.line = vi.fn();
+      this.save = mockSave;
+    } as any);
+    vi.mocked(api.handleTranslate).mockResolvedValueOnce({
+      direct_text: { text: 'Recognised text' },
+    });
+    renderPage();
+    await user.type(
+      screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
+      'Some text'
+    );
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+    await waitFor(() => expect(screen.getByTestId('results-section')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Export PDF/i }));
+    expect(mockSave).toHaveBeenCalledWith('fraktur-output.pdf');
+  });
+
+  it('calls Packer.toBlob and saveAs on Export DOCX click', async () => {
+    const user = userEvent.setup();
+    const { saveAs } = await import('file-saver');
+    const { Packer } = await import('docx');
+    vi.mocked(api.handleTranslate).mockResolvedValueOnce({
+      direct_text: { text: 'Recognised text' },
+    });
+    renderPage();
+    await user.type(
+      screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
+      'Some text'
+    );
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+    await waitFor(() => expect(screen.getByTestId('results-section')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Export DOCX/i }));
+    await waitFor(() => {
+      expect(Packer.toBlob).toHaveBeenCalled();
+      expect(saveAs).toHaveBeenCalled();
+    });
+  });
+
+  it('clears results and returns to input on New Translation click', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.handleTranslate).mockResolvedValueOnce({
+      direct_text: { text: 'Recognised text' },
+    });
+    renderPage();
+    await user.type(
+      screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
+      'Some text'
+    );
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+    await waitFor(() => expect(screen.getByTestId('results-section')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /New Translation/i }));
+    expect(screen.getByText('Fraktur Text Recogniser')).toBeInTheDocument();
+    expect(screen.queryByTestId('results-section')).not.toBeInTheDocument();
+  });
+
+  // ── Drag and drop ──────────────────────────────────────────────────────────
+
+  it('activates drag-active class on dragenter over the drop zone', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('File'));
+    const dropZone = document.querySelector('.file-drop-zone') as HTMLElement;
+    fireEvent.dragEnter(dropZone);
+    expect(dropZone).toHaveClass('drag-active');
+  });
+
+  it('maintains drag-active class on dragover', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('File'));
+    const dropZone = document.querySelector('.file-drop-zone') as HTMLElement;
+    fireEvent.dragOver(dropZone, { dataTransfer: { dropEffect: 'none' } });
+    expect(dropZone).toHaveClass('drag-active');
+  });
+
+  it('deactivates drag-active on dragleave when relatedTarget is outside', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('File'));
+    const dropZone = document.querySelector('.file-drop-zone') as HTMLElement;
+    fireEvent.dragEnter(dropZone);
+    fireEvent.dragLeave(dropZone, { relatedTarget: null });
+    expect(dropZone).not.toHaveClass('drag-active');
+  });
+
+  it('deactivates drag-active on drop and shows dropped filename', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('File'));
+    const dropZone = document.querySelector('.file-drop-zone') as HTMLElement;
+    fireEvent.dragEnter(dropZone);
+    const file = new File(['data'], 'dropped.jpg', { type: 'image/jpeg' });
+    // jsdom does not implement DataTransfer; build a FileList-compatible object
+    const fileList = Object.assign([file], {
+      item: (i: number) => (i === 0 ? file : null),
+    }) as unknown as FileList;
+    fireEvent.drop(dropZone, { dataTransfer: { files: fileList } });
+    expect(dropZone).not.toHaveClass('drag-active');
+    expect(screen.getByText('dropped.jpg')).toBeInTheDocument();
+  });
+
+  it('opens file browser on Enter key press on the drop zone', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('File'));
+    const dropZone = document.querySelector('.file-drop-zone') as HTMLElement;
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+    fireEvent.keyDown(dropZone, { key: 'Enter' });
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+
+  // ── Camera ────────────────────────────────────────────────────────────────
+
+  it('shows error when browser does not support getUserMedia', async () => {
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('Camera'));
+    await user.click(screen.getByRole('button', { name: /Open Camera/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Live camera preview is not supported in this browser/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows Stop button when camera starts successfully', async () => {
+    const mockStream = {
+      getTracks: () => [{ stop: vi.fn() }],
+      getVideoTracks: () => [{ getSettings: () => ({ deviceId: 'default' }) }],
+    };
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(mockStream),
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+    vi.spyOn(HTMLVideoElement.prototype, 'play').mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('Camera'));
+    await user.click(screen.getByRole('button', { name: /Open Camera/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Stop/i })).toBeInTheDocument();
+    });
+  });
+
+  it('hides Stop button after clicking Stop', async () => {
+    const mockStream = {
+      getTracks: () => [{ stop: vi.fn() }],
+      getVideoTracks: () => [{ getSettings: () => ({ deviceId: 'default' }) }],
+    };
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(mockStream),
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+    vi.spyOn(HTMLVideoElement.prototype, 'play').mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('Camera'));
+    await user.click(screen.getByRole('button', { name: /Open Camera/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /Stop/i })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Stop/i }));
+    expect(screen.queryByRole('button', { name: /Stop/i })).not.toBeInTheDocument();
+  });
+
+  it('shows camera error when getUserMedia rejects', async () => {
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockRejectedValue(new Error('Permission denied')),
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('Camera'));
+    await user.click(screen.getByRole('button', { name: /Open Camera/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Camera access failed: Permission denied/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows camera-not-ready error when Capture is clicked with zero video dimensions', async () => {
+    const mockStream = {
+      getTracks: () => [{ stop: vi.fn() }],
+      getVideoTracks: () => [{ getSettings: () => ({ deviceId: 'default' }) }],
+    };
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(mockStream),
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+    vi.spyOn(HTMLVideoElement.prototype, 'play').mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('Camera'));
+    await user.click(screen.getByRole('button', { name: /Open Camera/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /Capture/i })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Capture/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Camera preview is not ready yet/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── API Key panel ─────────────────────────────────────────────────────────
+
+  it('closes API key panel when clicking outside', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /API Key/i }));
+    expect(screen.getByPlaceholderText('sk-or-v1-...')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('sk-or-v1-...')).not.toBeInTheDocument();
+    });
+  });
+
+  it('toggles API key visibility between password and text', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /API Key/i }));
+    const input = screen.getByPlaceholderText('sk-or-v1-...');
+    expect(input).toHaveAttribute('type', 'password');
+    await user.click(screen.getByTitle('Show key'));
+    expect(input).toHaveAttribute('type', 'text');
+    await user.click(screen.getByTitle('Hide key'));
+    expect(input).toHaveAttribute('type', 'password');
+  });
+
+  it('drag-drop with empty file list does nothing', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('File'));
+    const dropZone = document.querySelector('.file-drop-zone') as HTMLElement;
+    fireEvent.dragEnter(dropZone);
+    expect(dropZone).toHaveClass('drag-active');
+    const emptyList = Object.assign([], { item: () => null }) as unknown as FileList;
+    fireEvent.drop(dropZone, { dataTransfer: { files: emptyList } });
+    expect(dropZone).not.toHaveClass('drag-active');
+    expect(screen.getByText('Click to upload or drag and drop')).toBeInTheDocument();
+  });
+
+  it('handles camera photo captured via native camera input', async () => {
+    Object.defineProperty(global.URL, 'createObjectURL', {
+      value: vi.fn().mockReturnValue('blob:mock-url'),
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(global.URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('Camera'));
+
+    const cameraInput = document.querySelector('input[capture]') as HTMLInputElement;
+    const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+    const fileList = Object.assign([file], {
+      item: (i: number) => (i === 0 ? file : null),
+    }) as unknown as FileList;
+    Object.defineProperty(cameraInput, 'files', { value: fileList, configurable: true });
+    fireEvent.change(cameraInput);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Retake/i })).toBeInTheDocument();
+    });
+  });
+
+  it('clicking Retake clears camera preview and hides Retake button', async () => {
+    Object.defineProperty(global.URL, 'createObjectURL', {
+      value: vi.fn().mockReturnValue('blob:mock-url'),
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(global.URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(global.navigator, 'mediaDevices', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText('Camera'));
+
+    const cameraInput = document.querySelector('input[capture]') as HTMLInputElement;
+    const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+    const fileList = Object.assign([file], {
+      item: (i: number) => (i === 0 ? file : null),
+    }) as unknown as FileList;
+    Object.defineProperty(cameraInput, 'files', { value: fileList, configurable: true });
+    fireEvent.change(cameraInput);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Retake/i })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /Retake/i }));
+    expect(screen.queryByRole('button', { name: /Retake/i })).not.toBeInTheDocument();
+  });
+
+  it('clicking API Key in Calamari mode switches back to Gemini and opens panel', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('switch', { name: /OCR engine is Gemini/i }));
+    expect(screen.getByRole('switch', { name: /OCR engine is Calamari/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /API Key/i }));
+    // Clicking API Key in Calamari mode switches engine back to Gemini and opens the panel
+    expect(screen.getByRole('switch', { name: /OCR engine is Gemini/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('sk-or-v1-...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('sk-or-v1-...')).not.toBeDisabled();
   });
 });

--- a/OCR-FRONTEND/src/__tests__/Translatorpage.test.tsx
+++ b/OCR-FRONTEND/src/__tests__/Translatorpage.test.tsx
@@ -138,7 +138,7 @@ describe('TranslatorPage', () => {
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByText('File'));
-    expect(screen.getByRole('button', { name: /Select File/i })).toBeInTheDocument();
+    expect(screen.getByText('Select File', { selector: 'button' })).toBeInTheDocument();
   });
 
   it('Recognise Text button is disabled on File tab with no file selected', async () => {


### PR DESCRIPTION
## Summary

- Fix an ambiguous `getByRole` query in `TranslatorPage` tests that caused CI to fail (multiple elements matched `Select File`)
- Expand test coverage from **58% → 84% statements** across all frontend components


Result
Coverage after: 84.6% statements | 74.1% branches | 89.4% functions | 86.2% lines (170 tests, 0 failures)
## What was added

**ResultView** — Calamari quality warning, zoom-in/out via wheel, pointer-based pan (start/move/end/cancel/leave), pointer capture release, zoom reset on tab switch

**TranslatorPage** — credits error display (CreditsErrorCard), view-results banner, copy to clipboard, export PDF (jsPDF mock), export DOCX (docx + file-saver mock), drag-enter/over/leave/drop, camera unsupported error, camera start/stop via mocked getUserMedia, camera capture error, camera photo via file input, retake photo, API key panel close on outside click, API key visibility toggle, Calamari mode switching via API Key button

**Navbar** — localStorage API key passed to `getCredits`, credit refresh on `apikey-changed` event, credit refresh on `credits-refresh` event


## Closes

Issues 100