### PR TITLE
Refine text input refinement

### DIFF
--- a/Backend/src/ocrApp/calamari_ocr_service.py
+++ b/Backend/src/ocrApp/calamari_ocr_service.py
@@ -6,10 +6,20 @@ import tempfile
 from io import BytesIO
 from pathlib import Path
 
-import kraken
 from PIL import Image, ImageFilter, ImageOps
-from kraken import blla, binarization
-from kraken.lib import vgsl
+
+try:
+    import kraken
+    from kraken import blla, binarization
+    from kraken.lib import vgsl
+except ImportError as exc:
+    kraken = None
+    blla = None
+    binarization = None
+    vgsl = None
+    KRAKEN_IMPORT_ERROR = exc
+else:
+    KRAKEN_IMPORT_ERROR = None
 
 from .preprocessing import convert_file_to_base64_jpg
 
@@ -25,6 +35,12 @@ def merge_calamari_lines(lines: list[str]) -> str:
 
 class CalamariOCRService:
     def __init__(self):
+        if KRAKEN_IMPORT_ERROR is not None:
+            raise RuntimeError(
+                "Calamari dependencies are not installed. "
+                "Install kraken/calamari or use Gemini mode."
+            ) from KRAKEN_IMPORT_ERROR
+
         self.model_path = (
             Path(__file__).resolve().parents[2]
             / "ml_models"

--- a/Backend/src/ocrApp/services.py
+++ b/Backend/src/ocrApp/services.py
@@ -1,11 +1,11 @@
-import base64
 import logging
-import mimetypes
-from urllib import response
+import time
+
 import requests
 from django.conf import settings
+
 from .preprocessing import convert_file_to_base64_jpg
-import time
+
 logger = logging.getLogger(__name__)
 
 # The prompt sent to Gemini for Fraktur OCR recognition
@@ -43,6 +43,61 @@ class GeminiOCRService:
         self.base_url = settings.OPENROUTER_BASE_URL
         self.url = f"{self.base_url}/chat/completions"
 
+    @staticmethod
+    def _extract_completion_text(response_json) -> str:
+        if "choices" not in response_json or not response_json["choices"]:
+            raise Exception(f"Invalid API response: {response_json}")
+
+        choice = response_json["choices"][0]
+        content = choice.get("message", {}).get("content")
+
+        if isinstance(content, list):
+            content = "".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict)
+            )
+
+        if not isinstance(content, str) or not content.strip():
+            finish_reason = choice.get("finish_reason", "unknown")
+            raise Exception(
+                f"Model returned empty content "
+                f"(finish_reason: {finish_reason})."
+            )
+
+        return content.strip()
+
+    def _request_chat_completion(self, messages) -> str:
+        if not self.api_key:
+            raise Exception("OpenRouter API key is not configured.")
+
+        payload = {
+            "model": self.model,
+            "messages": messages,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        response = requests.post(
+            self.url,
+            headers=headers,
+            json=payload,
+            timeout=300,
+        )
+
+        if response.status_code != 200:
+            raise Exception(f"API request failed: {response.text}")
+
+        try:
+            response_json = response.json()
+        except ValueError:
+            raise Exception(f"Invalid JSON response: {response.text}")
+
+        return self._extract_completion_text(response_json)
+
     def recognise(self, file) -> tuple[str, str]:
         """
         Returns (recognised_text, preview_b64).
@@ -75,45 +130,8 @@ class GeminiOCRService:
                     }
                 ]
 
-                payload = {
-                    "model": self.model,
-                    "messages": messages,
-                }
-
-                headers = {
-                    "Authorization": f"Bearer {self.api_key}",
-                    "Content-Type": "application/json",
-                }
-
-                response = requests.post(
-                    self.url,
-                    headers=headers,
-                    json=payload,
-                    timeout=300,
-                )
-
-                if response.status_code != 200:
-                    raise Exception(f"API request failed: {response.text}")
-
-                try:
-                    response_json = response.json()
-                except ValueError:
-                    raise Exception(f"Invalid JSON response: {response.text}")
-
-                if "choices" not in response_json or not response_json["choices"]:
-                    raise Exception(f"Invalid API response: {response_json}")
-
-                choice = response_json["choices"][0]
-                content = choice.get("message", {}).get("content")
-
-                if not content or not content.strip():
-                    finish_reason = choice.get("finish_reason", "unknown")
-                    raise Exception(
-                        f"Model returned empty content "
-                        f"(finish_reason: {finish_reason})."
-                    )
-
-                return content.strip(), image_b64
+                content = self._request_chat_completion(messages)
+                return content, image_b64
 
             except Exception as e:
                 last_error = e
@@ -123,3 +141,41 @@ class GeminiOCRService:
                     time.sleep(2)
 
         raise Exception(f"Gemini OCR failed after {max_attempts} attempts: {last_error}")
+
+    def process_text(self, text: str) -> str:
+        """
+        Refine direct Fraktur/transcribed text input through Gemini/OpenRouter.
+        """
+
+        cleaned_text = text.strip()
+        if not cleaned_text:
+            raise ValueError("No text provided.")
+
+        messages = [
+            {
+                "role": "system",
+                "content": TEXT_SYSTEM_PROMPT,
+            },
+            {
+                "role": "user",
+                "content": cleaned_text,
+            },
+        ]
+
+        max_attempts = 3
+        last_error = None
+
+        for attempt in range(max_attempts):
+            try:
+                return self._request_chat_completion(messages)
+
+            except Exception as e:
+                last_error = e
+                print(f"Gemini text refinement attempt {attempt + 1} failed: {e}")
+
+                if attempt < max_attempts - 1:
+                    time.sleep(2)
+
+        raise Exception(
+            f"Gemini text refinement failed after {max_attempts} attempts: {last_error}"
+        )

--- a/Backend/src/ocrApp/tests.py
+++ b/Backend/src/ocrApp/tests.py
@@ -5,10 +5,11 @@ from unittest.mock import Mock, patch
 
 import requests
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from PIL import Image
 
 from .models import ContactMessage
+from .services import GeminiOCRService, TEXT_SYSTEM_PROMPT
 
 
 def create_test_image(name="page.jpg", fmt="JPEG", content_type="image/jpeg"):
@@ -219,6 +220,51 @@ class TextInputApiTests(TestCase):
         data = response.json()
         self.assertIn("text-input.txt", data)
         self.assertIn("OpenRouter unavailable", data["text-input.txt"]["error"])
+
+
+@override_settings(
+    OPENROUTER_API_KEY="server-key",
+    OPENROUTER_MODEL="google/test-model",
+    OPENROUTER_BASE_URL="https://openrouter.test/api/v1",
+)
+class GeminiOCRServiceTextTests(TestCase):
+    @patch("ocrApp.services.requests.post")
+    def test_process_text_posts_plain_text_request_and_returns_result(self, mock_post):
+        fake_response = Mock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "  Moderner deutscher Text  ",
+                    }
+                }
+            ]
+        }
+        mock_post.return_value = fake_response
+
+        service = GeminiOCRService()
+        result = service.process_text("  Historischer Fraktur Text  ")
+
+        self.assertEqual(result, "Moderner deutscher Text")
+        mock_post.assert_called_once()
+
+        kwargs = mock_post.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer server-key")
+        self.assertEqual(kwargs["json"]["model"], "google/test-model")
+        self.assertEqual(
+            kwargs["json"]["messages"],
+            [
+                {"role": "system", "content": TEXT_SYSTEM_PROMPT},
+                {"role": "user", "content": "Historischer Fraktur Text"},
+            ],
+        )
+
+    def test_process_text_rejects_blank_input(self):
+        service = GeminiOCRService()
+
+        with self.assertRaises(ValueError):
+            service.process_text("   ")
 
 
 class CreditsApiTests(TestCase):

--- a/Backend/src/ocrApp/views.py
+++ b/Backend/src/ocrApp/views.py
@@ -180,12 +180,12 @@ class TextRecogniseView(View):
         except Exception as exc:
             logger.exception("Failed to process direct text input.")
             return JsonResponse(
-                {"text-input.txt": {"error": str(exc)}},
+                {"text-input.txt": {"error": str(exc), "engine": "gemini"}},
                 status=200,
             )
 
         return JsonResponse(
-            {"text-input.txt": {"text": processed_text}},
+            {"text-input.txt": {"text": processed_text, "engine": "gemini"}},
             status=200,
         )
 

--- a/OCR-FRONTEND/src/__tests__/Navbar.test.tsx
+++ b/OCR-FRONTEND/src/__tests__/Navbar.test.tsx
@@ -17,6 +17,12 @@ const renderNavbar = (initialPath = '/') =>
     </MemoryRouter>
   );
 
+const credits = (remaining: number) => ({
+  total_credits: remaining,
+  total_usage: 0,
+  remaining,
+});
+
 describe('Navbar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -56,7 +62,7 @@ describe('Navbar', () => {
   });
 
   it('shows credits when API returns a value', async () => {
-    vi.mocked(api.getCredits).mockResolvedValue({ remaining: 3.75 });
+    vi.mocked(api.getCredits).mockResolvedValue(credits(3.75));
     renderNavbar();
     await waitFor(() => {
       expect(screen.getByText('$3.75')).toBeInTheDocument();
@@ -81,7 +87,7 @@ describe('Navbar', () => {
 
   it('passes the api key from localStorage to getCredits', async () => {
     localStorage.setItem('openrouter_api_key', 'sk-my-key');
-    vi.mocked(api.getCredits).mockResolvedValue({ remaining: 2.0 });
+    vi.mocked(api.getCredits).mockResolvedValue(credits(2.0));
     renderNavbar();
     await waitFor(() => {
       expect(api.getCredits).toHaveBeenCalledWith('sk-my-key');
@@ -90,8 +96,8 @@ describe('Navbar', () => {
 
   it('re-fetches credits when apikey-changed event fires', async () => {
     vi.mocked(api.getCredits)
-      .mockResolvedValueOnce({ remaining: 1.0 })
-      .mockResolvedValueOnce({ remaining: 3.0 });
+      .mockResolvedValueOnce(credits(1.0))
+      .mockResolvedValueOnce(credits(3.0));
     renderNavbar();
     await waitFor(() => expect(screen.getByText('$1.00')).toBeInTheDocument());
     window.dispatchEvent(new Event('apikey-changed'));
@@ -100,8 +106,8 @@ describe('Navbar', () => {
 
   it('re-fetches credits when credits-refresh event fires', async () => {
     vi.mocked(api.getCredits)
-      .mockResolvedValueOnce({ remaining: 5.0 })
-      .mockResolvedValueOnce({ remaining: 4.0 });
+      .mockResolvedValueOnce(credits(5.0))
+      .mockResolvedValueOnce(credits(4.0));
     renderNavbar();
     await waitFor(() => expect(screen.getByText('$5.00')).toBeInTheDocument());
     window.dispatchEvent(new Event('credits-refresh'));

--- a/OCR-FRONTEND/src/__tests__/Translatorpage.test.tsx
+++ b/OCR-FRONTEND/src/__tests__/Translatorpage.test.tsx
@@ -74,9 +74,6 @@ const renderPage = () =>
     </MemoryRouter>
   );
 
-const makeFile = (name = 'scan.jpg', type = 'image/jpeg') =>
-  new File(['binary'], name, { type });
-
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe('TranslatorPage', () => {
@@ -221,15 +218,29 @@ describe('TranslatorPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('disables Recognise Text button in Calamari mode on text tab', async () => {
+  it('processes text with Gemini when Calamari mode is selected', async () => {
     const user = userEvent.setup();
+    vi.mocked(api.handleTranslate).mockResolvedValueOnce({
+      direct_text: { text: 'Recognised text', engine: 'gemini' },
+    });
+
     renderPage();
     await user.type(
       screen.getByPlaceholderText(/Paste or type your Fraktur text/i),
       'Some text'
     );
     await user.click(screen.getByRole('switch', { name: /OCR engine is Gemini/i }));
-    expect(screen.getByRole('button', { name: /Recognise Text/i })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: /Recognise Text/i }));
+
+    await waitFor(() => {
+      expect(api.handleTranslate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'text',
+          data: 'Some text',
+          engine: 'gemini',
+        })
+      );
+    });
   });
 
   // ── API Key Panel ────────────────────────────────────────────────────────────

--- a/OCR-FRONTEND/src/__tests__/api.test.ts
+++ b/OCR-FRONTEND/src/__tests__/api.test.ts
@@ -55,22 +55,22 @@ class MockXHR {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function makeFetchOk(body: unknown, status = 200) {
+function makeFetchOk(body: unknown, status = 200): Response {
   return {
     ok: true,
     status,
     statusText: 'OK',
     json: vi.fn().mockResolvedValue(body),
-  };
+  } as unknown as Response;
 }
 
-function makeFetchError(status: number, body: unknown = null) {
+function makeFetchError(status: number, body: unknown = null): Response {
   return {
     ok: false,
     status,
     statusText: 'Error',
     json: vi.fn().mockResolvedValue(body),
-  };
+  } as unknown as Response;
 }
 
 function makeFile(name = 'scan.jpg', type = 'image/jpeg'): File {

--- a/OCR-FRONTEND/src/pages/TranslatorPage.tsx
+++ b/OCR-FRONTEND/src/pages/TranslatorPage.tsx
@@ -688,7 +688,8 @@ const exportToDocx = async () => {
         ? selectedFiles.length > 0
         : Boolean(cameraFile);
   const isCalamariMode = ocrEngine === 'calamari';
-  const isTextCalamariBlocked = activeTab === 'text' && isCalamariMode;
+  const effectiveEngine: OcrEngine = activeTab === 'text' ? 'gemini' : ocrEngine;
+  const effectiveEngineDisplayName = effectiveEngine === 'calamari' ? 'Calamari' : 'Gemini';
   const engineDisplayName = isCalamariMode ? 'Calamari' : 'Gemini';
   const nextEngineDisplayName = isCalamariMode ? 'Gemini' : 'Calamari';
   const engineHoverText = isCalamariMode
@@ -875,7 +876,9 @@ const exportToDocx = async () => {
           <div className="processing-banner">
             <div className="processing-spinner" />
             <span>
-              Recognising your file with {engineDisplayName}... This may take a few moments.
+              {activeTab === 'text'
+                ? `Refining your text with ${effectiveEngineDisplayName}... This may take a few moments.`
+                : `Recognising your file with ${effectiveEngineDisplayName}... This may take a few moments.`}
             </span>
           </div>
         )}
@@ -1101,11 +1104,8 @@ const exportToDocx = async () => {
             <div className="input-actions">
               <button 
               className="btn-translate" 
-              disabled={!hasInput || loading || isTextCalamariBlocked}
+              disabled={!hasInput || loading}
               onClick={async () => {
-                if (isTextCalamariBlocked) {
-                  return;
-                }
                 setLoadingPhase('uploading');
                 setError(null);
                 setOutputItems([]);
@@ -1127,10 +1127,10 @@ const exportToDocx = async () => {
                     type: activeTab === 'text' ? 'text' : 'file',
                     data: uploadPayload,
                     apiKey: apiKey.trim() || undefined,
-                    engine: ocrEngine,
+                    engine: effectiveEngine,
                     onUploadDone: () => {
                       setLoadingPhase('processing');
-                      if (activeTab !== 'text') {
+                      if (effectiveEngine === 'gemini') {
                         window.dispatchEvent(new Event('credits-refresh'));
                       }
                     },
@@ -1142,7 +1142,7 @@ const exportToDocx = async () => {
                       text: value?.text,
                       sourceText: activeTab === 'text' ? inputText : undefined,
                       error: value?.error,
-                      engine: value?.engine ?? ocrEngine,
+                      engine: value?.engine ?? effectiveEngine,
                     })
                   );
 
@@ -1164,7 +1164,7 @@ const exportToDocx = async () => {
               }}
               >
               <FontAwesomeIcon icon={faLanguage} />
-              {loading ? `Recognising with ${engineDisplayName}...` : 'Recognise Text'}
+              {loading ? `Recognising with ${effectiveEngineDisplayName}...` : 'Recognise Text'}
               </button>
               <button
                 className="btn-clear"

--- a/OCR-FRONTEND/vite.config.ts
+++ b/OCR-FRONTEND/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
 import tailwindcss from '@tailwindcss/vite'


### PR DESCRIPTION
## Summary

Refineed the full direct text input refinement flow.

## Changes

- Added backend `GeminiOCRService.process_text()` to send plain text input to OpenRouter/Gemini using the existing text refinement prompt.
- Connected `/api/ocr/text/` to return refined text results with `engine: "gemini"`.
- Updated the frontend Text tab so text input always uses Gemini, even when Calamari is selected, since Calamari only supports image OCR.
- Added a clearer processing message for text refinement.
- Made Calamari dependencies fail only when Calamari mode is actually used, so Gemini/text workflows can run without Kraken installed.
- Added backend and frontend tests for text input behavior.
- Fixed frontend test/build typing issues in API and Navbar tests.
- Updated Vite config import so `npm run build` passes with Vitest config.

## Verification

- `.\.venv\Scripts\python.exe manage.py test ocrApp`
- `npm.cmd test -- --run`
- `npm.cmd run build`